### PR TITLE
Edited all documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 bower_components
 build
 .tmp
+.idea

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ you to solve these common user management tasks in your AngularJS application:
 * Conditionally render parts of your UI, based on login state
 * Control access to application routes
 
-Under the hood this library uses Oauth Access Tokens (JWTs) as the authentication
+Under the hood, this library uses Oauth Access Tokens (JWTs) as the authentication
 mechanism.  This library implements the best-practice approaches that we outline in
 [Token Based Authentication for Single Page Apps (SPAs)](https://stormpath.com/blog/token-auth-spa/).
 
@@ -55,13 +55,13 @@ Curious?  Here's some screenies that show you what's included:
 
 ## Installation
 
-If you are using Bower simply install it:
+If you are using Bower, simply install it:
 
 ```bash
 bower install --save stormpath-sdk-angularjs
 ```
 
-If you want to manually load the minified scripts you can grab them from the `dist`
+If you want to manually load the minified scripts, you can grab them from the `dist`
 folder in this repo and include them manually:
 
 ```html
@@ -82,12 +82,12 @@ The templates are optional, see the documentation for more information.
 
 ## Documentation & Guide
 
-If you are starting a new project the
+If you are starting a new project, the
 [Stormpath AngularJS Guide](http://docs.stormpath.com/angularjs/guide/index.html)
 will be your best choice.  It will help you get started with a new project and an API
 server for your application.
 
-If you already have an Angular project you will want to visit the
+If you already have an Angular project, you will want to visit the
 [Stormpath AngularJS SDK API Documenation](https://docs.stormpath.com/angularjs/sdk/).
 That documentation will show you all the available directives and services that you
 can use in your application.
@@ -96,7 +96,7 @@ can use in your application.
 
 This repository contains a working example application in the `example/dashboard-app` folder.
 This is the application that we build in the [Stormpath AngularJS Guide](http://docs.stormpath.com/angularjs/guide/index.html).
-If you would like to skip the guide and start using the example applicion, do the following:
+If you would like to skip the guide and start using the example application, do the following:
 
 1) Install [Bower] and [Grunt] if you don't already have them
 

--- a/dist/stormpath-sdk-angularjs.js
+++ b/dist/stormpath-sdk-angularjs.js
@@ -20,12 +20,10 @@ if (typeof module !== "undefined" && typeof exports !== "undefined" && module.ex
  *
  * @description
  *
- *
- *
  * ## Welcome!  Let's get started
  *
- * You are reading the API documentation for the Stormpath AngularJS SDK,
- * you are moments away from sovling all kinds of user management issues
+ * You are reading the API documentation for the Stormpath AngularJS SDK.
+ * You are moments away from solving all kinds of user management issues
  * in your Angular application :)
  *
  * ## Installation - Bower
@@ -50,7 +48,7 @@ if (typeof module !== "undefined" && typeof exports !== "undefined" && module.ex
  *
  * ## Configuration
  *
- * You will need to add `stormpath` as a depenency of your Angular application,
+ * You will need to add `stormpath` as a dependency of your Angular application
  * and the templates if you will be using those:
  *
  * <pre>
@@ -61,17 +59,17 @@ if (typeof module !== "undefined" && typeof exports !== "undefined" && module.ex
  *
  * ## Templates are optional
  *
- * This libray includes some default view templates for forms, such as
+ * This library includes some default view templates for forms, such as
  * registration and login.  You have the option to specify your own templates
- * for those directives.  If you are using your own templates it does not make
+ * for those directives.  If you are using your own templates, it does not make
  * sense to include our defaults.
  *
- * If you are using the manual installation: sipmply remove the file
- * `stormpath-sdk-angularjs.tpls.min.js`
+ * If you are using the manual installation, simply remove the file
+ * `stormpath-sdk-angularjs.tpls.min.js`.
  *
  * If you are using Bower, you can specify an override for this module
  * and only include the core javascript.  This is done inside your
- * `bower.json` file:
+ * `bower.json` file.
  *
  * <pre>
  * {
@@ -94,18 +92,23 @@ if (typeof module !== "undefined" && typeof exports !== "undefined" && module.ex
  * @description
  * The Stormpath State Config is an object that you can define on a
  * state.  You will need to be using the UI Router module, and you need
- * to enable the integration by calling  {@link stormpath.$stormpath#methods_uiRouter $stormpath.uiRouter()}
- * @property {boolean} authenticate If `true`, the user must be
- * authenticated in order to view this state.  If the user is not authenticated they will
- * be redircted to the `login` state.  After they login they will be redicted to
+ * to enable the integration by calling  {@link stormpath.$stormpath#methods_uiRouter $stormpath.uiRouter()}.
+ *
+ * @property {boolean} authenticate
+ *
+ * If `true`, the user must be authenticated in order to view this state.
+ * If the user is not authenticated, they will
+ * be redirected to the `login` state.  After they login, they will be redirected to
  * the state that was originally requested.
  *
  * @property {object} authorize
  *
- * An object which defines access control rules.  Currently is supports a group-based
- * check.  See the example below
+ * An object which defines access control rules.  Currently supports a group-based
+ * check.  See the example below:
  *
- * @property {boolean} waitForUser If `true`, delay the state transition until we know
+ * @property {boolean} waitForUser
+ *
+ * If `true`, delay the state transition until we know
  * if the user is authenticated or not.  This is useful for situations where
  * you want everyone to see this state, but the state may look different
  * depending on the user's authentication state.
@@ -117,7 +120,7 @@ if (typeof module !== "undefined" && typeof exports !== "undefined" && module.ex
  * angular.module('myApp')
  *   .config(function ($stateProvider) {
  *
- *     // Wait until we know if the user is logged in, before showing the homepage
+ *     // Wait until we know if the user is logged in before showing the homepage
  *     $stateProvider
  *       .state('main', {
  *         url: '/',
@@ -221,26 +224,29 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
        * @ngdoc function
        * @name stormpath#uiRouter
        * @methodOf stormpath.$stormpath
+       *
        * @description
+       *
        * Call this method to enable the integration with the UI Router module.
        *
-       * When enabled you can define {@link stormpath.SpStateConfig:SpStateConfig Stormpath State Configurations} on your UI states, this
+       * When enabled you can define {@link stormpath.SpStateConfig:SpStateConfig Stormpath State Configurations} on your UI states. This
        * object allows you to define access control for the state.  See the
        * examples below
        *
        * @param {object} config
-       * * **`loginState`** - The UI state name that we should send the user
-       * to if they need to login.  You'll probably use `login` for this value
        *
-       * * **`autoRedirect`** - Defaults to true.  After the user logins at
-       * the state defined by `loginState` they will be redirected back to the
-       * state that was originally requested
+       * * **`loginState`** - The UI state name that we should send the user
+       * to if they need to login.  You'll probably use `login` for this value.
+       *
+       * * **`autoRedirect`** - Defaults to true.  After the user logs in at
+       * the state defined by `loginState`, they will be redirected back to the
+       * state that was originally requested.
        *
        * * **`defaultPostLoginState`**  - Where the user should be sent, after login,
        * if they have visited the login page directly.  If you do not define a value,
        * nothing will happen at the login state.  You can alternatively use the
        * {@link stormpath.authService.$auth#events_$authenticated $authenticated} event to know
-       * that login is successful
+       * that login is successful.
        *
        * @example
        * <pre>
@@ -250,7 +256,7 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
        *       loginState: 'login',
        *       defaultPostLoginState: 'main'
        *     });
-       *   })
+       *   });
        * </pre>
        */
       StormpathService.prototype.uiRouter = function uiRouter(config){
@@ -392,7 +398,8 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
  * @name stormpath.ifUser:ifUser
  *
  * @description
- * Use this directive to conditionally show an element, if the user is logged in.
+ *
+ * Use this directive to conditionally show an element if the user is logged in.
  *
  * @example
  * <pre>
@@ -420,7 +427,7 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
  * @name stormpath.ifNotUser:ifNotUser
  *
  * @description
- * Use this directive to conditionally show an element, if the user is NOT logged in.
+ * Use this directive to conditionally show an element if the user is NOT logged in.
  *
  * @example
  * <pre>
@@ -448,8 +455,9 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
  * @name stormpath.ifUserInGroup:ifUserInGroup
  *
  * @description
+ *
  * Use this directive to conditionally show an element if the user is logged in
- * and is a member of the group that is specified by the string
+ * and is a member of the group that is specified by the string.
  *
  * @example
  * <pre>
@@ -477,8 +485,9 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
  * @name stormpath.ifUserNotInGroup:ifUserNotInGroup
  *
  * @description
+ *
  * Use this directive to conditionally show an element if the user is logged in
- * and is a member of the group that is specified by the string
+ * and is a member of the group that is specified by the string.
  *
  * @example
  * <pre>
@@ -506,8 +515,9 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
  * @name stormpath.whileResolvingUser:while-resolving-user
  *
  * @description
+ *
  * # [DEPRECATED]
- * Please use {@link stormpath.ifUserStateUnknown:ifUserStateUnknown ifUserStateUnknown} instead
+ * Please use {@link stormpath.ifUserStateUnknown:ifUserStateUnknown ifUserStateUnknown} instead.
  *
  */
 .directive('whileResolvingUser',['$user','$rootScope',function($user,$rootScope){
@@ -528,6 +538,7 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
  * @name stormpath.ifUserStateKnown:ifUserStateKnown
  *
  * @description
+ *
  * Use this directive to show an element once the user state is known.
  * The inverse of {@link stormpath.ifUserStateUnknown:ifUserStateUnknown ifUserStateUnknown}, you can
  * use this directive to show an element after we know if the user is logged in
@@ -563,6 +574,7 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
  * @name stormpath.ifUserStateUnknown:ifUserStateUnknown
  *
  * @description
+ *
  * Use this directive to show an element, while waiting to know if the user
  * is logged in or not.  This is useful if you want to show a loading graphic
  * over your application while you are waiting for the user state.
@@ -593,7 +605,8 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
  * @name stormpath.spLogout:spLogout
  *
  * @description
- * This directive adds a click handler to the element.  When clicked the user will be logged out.
+ *
+ * This directive adds a click handler to the element.  When clicked, the user will be logged out.
  *
  * @example
  * <pre>
@@ -614,18 +627,18 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
  * @ngdoc overview
  * @name  stormpath.authService
  * @description
- * This module provides the {@link stormpath.authService.$auth $auth} service
+ * This module provides the {@link stormpath.authService.$auth $auth} service.
  *
- * Currently this provider does not have any configuration methods
+ * Currently, this provider does not have any configuration methods.
  */
 /**
  * @ngdoc object
  * @name stormpath.authService.$authProvider
  * @description
  *
- * Provides the {@link stormpath.authService.$auth $auth} service
+ * Provides the {@link stormpath.authService.$auth $auth} service.
  *
- * Currently this provider does not have any configuration methods
+ * Currently, this provider does not have any configuration methods.
  */
 angular.module('stormpath.auth',['stormpath.CONFIG'])
 .config(['$injector','STORMPATH_CONFIG',function $authProvider($injector,STORMPATH_CONFIG){
@@ -647,16 +660,22 @@ angular.module('stormpath.auth',['stormpath.CONFIG'])
          * @ngdoc function
          * @name  stormpath.authService.$auth#authenticate
          * @methodOf stormpath.authService.$auth
-         * @param {Object} credentialData An object literal for passing
-         * usernmae & password, or social provider token
+         * @param {Object} credentialData
+         *
+         * An object literal for passing username & password, or social provider token.
          * @description
+         *
          * Sends the provided credential data to your backend server, the server
          * handler should verify the credentials and return an access token which is
          * store in an HTTP-only cookie.
-         * @returns {promise} A promise which is resolved with the authntication
-         * response or error response (both are response objects from the $http
+         *
+         * @returns {promise}
+         *
+         * A promise which is resolved with the authentication response or error response (both are response objects from the $http
          * service).
+         *
          * @example
+         *
          * ## Username & Password example
          * <pre>
          * myApp.controller('LoginCtrl', function ($scope, $auth, $state) {
@@ -717,16 +736,21 @@ angular.module('stormpath.auth',['stormpath.CONFIG'])
          * @name stormpath.authService.$auth#$authenticated
          * @eventOf stormpath.authService.$auth
          * @eventType broadcast on root scope
+         *
          * @description
+         *
          * This event is broadcast when a call to
          * {@link stormpath.authService.$auth#methods_authenticate $auth.authenticate()}
-         * is successful
+         * is successful.
          *
-         * @param {Object} event Angular event object.
-         * @param {httpResponse} httpResponse The http response from the $http service.  If
-         * you are writing your access tokens to the response body when a user
-         * authenticates, you will want to use this response object to get access
-         * to that token.
+         * @param {Object} event
+         *
+         * Angular event object.
+         *
+         * @param {httpResponse} httpResponse
+         *
+         * The http response from the $http service.  If you are writing your access tokens to the response body when a user
+         * authenticates, you will want to use this response object to get access to that token.
          *
          */
         $rootScope.$broadcast(STORMPATH_CONFIG.AUTHENTICATION_SUCCESS_EVENT_NAME,response);
@@ -822,19 +846,22 @@ angular.module('stormpath')
  *
  * Use this directive on the page that users land on when they click an email verification link.
  * These links are sent after a user registers, see
- * {@link stormpath.spRegistrationForm:spRegistrationForm spRegistrationForm}
+ * {@link stormpath.spRegistrationForm:spRegistrationForm spRegistrationForm}.
  *
  * This directive will render a view which does the following:
  * * Verifies that the current URL has an `sptoken` in it.  Shows an error if not.
  * * Verifies the given `sptoken` with Stormpath, then:
  *   * If the token is valid, tell the user that confirmation is complete and prompt the user to login.
- *   * If the token is invalid (it is expired or malformed) we prompt the user to enter
+ *   * If the token is invalid (it is expired or malformed), we prompt the user to enter
  *     their email address, so that we can try sending them a new link.
  *
- * @param {string} template-url An alternate template URL, if you want
+ * @param {string} template-url
+ *
+ * An alternate template URL, if you want
  * to use your own template for the form.
  *
  * @example
+ *
  * <pre>
  * <!-- If you want to use the default template -->
  * <div class="container">
@@ -861,8 +888,8 @@ angular.module('stormpath')
 angular.module('stormpath')
 .provider('$spFormEncoder', [function $spFormEncoder(){
   /**
-   * This service is intenally exclude from NG Docs
-   * It is an internal utility
+   * This service is intentionally excluded from NG Docs
+   * It is an internal utility.
    */
 
   this.$get = [
@@ -1003,7 +1030,8 @@ angular.module('stormpath')
  * @name stormpath.spLoginForm:spLoginForm
  *
  * @description
- * This directive will render a pre-built login form, with all
+ *
+ * This directive will render a pre-built login form with all
  * the necessary fields.  After the login is a success, the following
  * will happen:
  *
@@ -1011,13 +1039,16 @@ angular.module('stormpath')
  * be fired.
  * *  If you have configured the {@link stormpath.$stormpath#methods_uiRouter UI Router Integration},
  * the following can happen:
- *  * The user is sent back to the view they originally requested
- *  * The user is sent to a default view of your choice
+ *  * The user is sent back to the view they originally requested.
+ *  * The user is sent to a default view of your choice.
  *
- * @param {string} template-url An alternate template URL, if you want
+ * @param {string} template-url
+ *
+ * An alternate template URL if you want
  * to use your own template for the form.
  *
  * @example
+ *
  * <pre>
  * <!-- If you want to use the default template -->
  * <div class="container">
@@ -1119,14 +1150,18 @@ angular.module('stormpath')
  * @name stormpath.spPasswordResetRequestForm:spPasswordResetRequestForm
  *
  * @description
- * This directive will render a pre-built form which prompts the user for thier
- * username/email.  If an account is found we will send them an email with a
+ *
+ * This directive will render a pre-built form which prompts the user for their
+ * username/email.  If an account is found, we will send them an email with a
  * password reset link.
  *
- * @param {string} template-url An alternate template URL, if you want
+ * @param {string} template-url
+ *
+ * An alternate template URL if you want
  * to use your own template for the form.
  *
  * @example
+ *
  * <pre>
  * <!-- If you want to use the default template -->
  * <div class="container">
@@ -1152,21 +1187,25 @@ angular.module('stormpath')
  * @name stormpath.spPasswordResetForm:spPasswordResetForm
  *
  * @description
+ *
  * Use this directive on the page that users land on when they click on a password
  * reset link.  To send users a password reset link, see
- * {@link stormpath.spPasswordResetRequestForm:spPasswordResetRequestForm spPasswordResetRequestForm}
+ * {@link stormpath.spPasswordResetRequestForm:spPasswordResetRequestForm spPasswordResetRequestForm}.
  *
  * This directive will render a password reset form which does the following:
  * * Verifies that the current URL has an `sptoken` in it.  Shows an error if not.
  * * Verifies the given `sptoken` with Stormpath, then:
  *   * If the token is valid, show a form which allows the user to enter a new password.
- *   * If the token is invalid (it is expired or malformed) we prompt the user to enter
+ *   * If the token is invalid (it is expired or malformed), we prompt the user to enter
  *     their email address, so that we can try sending them a new link.
  *
- * @param {string} template-url An alternate template URL, if you want
+ * @param {string} template-url
+ *
+ * An alternate template URL if you want
  * to use your own template for the form.
  *
  * @example
+ *
  * <pre>
  * <!-- If you want to use the default template -->
  * <div class="container">
@@ -1243,19 +1282,22 @@ angular.module('stormpath')
  * @ngdoc directive
  * @name stormpath.spRegistrationForm:spRegistrationForm
  *
- * @param {boolean} autoLogin Default `false`, automatically authenticate the user
+ * @param {boolean} autoLogin
+ *
+ * Default `false`. Automatically authenticate the user
  * after creation.  This makes a call to
- * {@link stormpath.authService.$auth#methods_authenticate $auth.authenticate} which will
+ * {@link stormpath.authService.$auth#methods_authenticate $auth.authenticate}, which will
  * trigger the event {@link stormpath.authService.$auth#events_$authenticated $authenticated}.
- * This is not
- * possible if the email verification workflow is enabled on the directory that
+ * This is not possible if the email verification workflow is enabled on the directory that
  * the account is created in.
  *
- * @param {string} postLoginState If using the `autoLogin` option, you can
- * specify the name of a UI state that the user should be redirected to after
- * they successfully register
+ * @param {string} postLoginState
+ *
+ * If using the `autoLogin` option, you can specify the name of a UI state that the user
+ * should be redirected to after they successfully have registered.
  *
  * @description
+ *
  * This directive will render a pre-built user registration form with the following
  * fields:
  *  * First Name
@@ -1263,7 +1305,7 @@ angular.module('stormpath')
  *  * Email
  *  * Password
  *
- * # Customizing the form
+ * # Customizing the Form
  *
  * If you would like to customize the form:
  *
@@ -1281,26 +1323,28 @@ angular.module('stormpath')
  *
  * # Email Verification
  *
- * If you are using the email verification workflow the default template has a message
+ * If you are using the email verification workflow, the default template has a message,
  * which will be shown to the user, telling them that they need to check their email
  * for verification.
  *
- * If you are NOT using the email verification workflow you can, optionally,
+ * If you are NOT using the email verification workflow, you can, optionally,
  * automatically login the user and redirect them to a UI state in your application.
  * See the options below.
- *
  *
  * # Server Interaction
  *
  * This directive makes a call to
  * {@link stormpath.userService.$user#methods_create $user.create()}
- * when it is ready to POST the form to the server, please see that method
+ * when it is ready to POST the form to the server. Please see that method
  * for more information.
  *
- * @param {string} template-url An alternate template URL, if you want
+ * @param {string} template-url
+ *
+ * An alternate template URL if you want
  * to use your own template for the form.
  *
  * @example
+ *
  * <pre>
  * <!-- If you want to use the default template -->
  * <div class="container">
@@ -1329,19 +1373,21 @@ angular.module('stormpath')
 /**
  * @ngdoc overview
  * @name stormpath.userService
+ *
  * @description
  *
- * This module provides the {@link stormpath.userService.$user $user} service
+ * This module provides the {@link stormpath.userService.$user $user} service.
  */
 
 /**
  * @ngdoc object
  * @name stormpath.userService.$userProvider
+ *
  * @description
  *
- * Provides the {@link stormpath.userService.$user $user} service
+ * Provides the {@link stormpath.userService.$user $user} service.
  *
- * Currently this provider does not have any configuration methods
+ * Currently, this provider does not have any configuration methods.
  */
 
 angular.module('stormpath.userService',['stormpath.CONFIG'])
@@ -1352,8 +1398,9 @@ angular.module('stormpath.userService',['stormpath.CONFIG'])
    * @name stormpath.userService.$user
    *
    * @description
+   *
    * Use this service to get the current user and do access control checks
-   * on the user
+   * on the user.
    */
 
   function User(data){
@@ -1381,8 +1428,11 @@ angular.module('stormpath.userService',['stormpath.CONFIG'])
          * @ngdoc function
          * @name stormpath.userService.$user#create
          * @methodOf stormpath.userService.$user
-         * @param {Object} accountData An object literal for passing the data
-         * for the new account.
+         *
+         * @param {Object} accountData
+         *
+         * An object literal for passing the data
+         * to the new account.
          *
          * Required fields:
          * * `givenName` - the user's first name
@@ -1391,9 +1441,10 @@ angular.module('stormpath.userService',['stormpath.CONFIG'])
          * * `password` - the password that the user wishes to use for their
          * account.  Must meet the password requirements that you have specified
          * on the directory that this account will be created in.
+         *
          * @description
          *
-         * Attemps to create a new user by submitting the given `accountData` as
+         * Attempts to create a new user by submitting the given `accountData` as
          * JSON to `/api/users`.  The POST endpoint can be modified via the
          * {@link stormpath.config#USER_COLLECTION_URI USER_COLLECTION_URI} config option.
          *
@@ -1402,25 +1453,26 @@ angular.module('stormpath.userService',['stormpath.CONFIG'])
          *
          * If email verification is enabled, you should send a `202` response instead.
          *
-         *  If you are using our Express.JS SDK you can simply attach the
+         *  If you are using our Express.JS SDK, you can simply attach the
          *  <a href="https://github.com/stormpath/stormpath-sdk-express#register" target="_blank">`register`</a> middleware
          * to your application and these responses will be handled automatically for you.
          *
-         * @returns {promise} A promise representing the operation to create a
-         * new user.  If an error occurs (duplicate email, weak password) the
+         * @returns {promise}
+         *
+         * A promise representing the operation to create a
+         * new user.  If an error occurs (duplicate email, weak password), the
          * promise will be rejected and the http response will be passed.
-         * If the operation is successful the promise
+         * If the operation is successful, the promise
          * will be resolved with a boolean `enabled` value.
          *
-         * * If `true`, the
-         * account's status is Enabled and you can proceed with authenticating the user.
+         * * If `true`, the account's status is Enabled and you can proceed with authenticating the user.
          *
          * * If `false`, the account's status is Unverified.
-         * This will be the case when you have
-         * enabled the email verification workflow on the directory of this
+         * This will be the case when you have enabled the email verification workflow on the directory of this
          * account.
          *
          * @example
+         *
          * <pre>
          * $user.create(accountData)
          *   .then(function(created){
@@ -1453,23 +1505,27 @@ angular.module('stormpath.userService',['stormpath.CONFIG'])
          * @ngdoc function
          * @name stormpath.userService.$user#get
          * @methodOf stormpath.userService.$user
+         *
          * @description
          *
          * Attempt to get the current user.  Returns a promise.  If the user
-         * is authenticated the promise will be resolved with the user object.
-         * If the user is not authenticated the promise will be rejected and
+         * is authenticated, the promise will be resolved with the user object.
+         * If the user is not authenticated, the promise will be rejected and
          * passed the error response from the $http service.
          *
-         * If you cannot make use of the promise you can also obseve the
+         * If you cannot make use of the promise, you can also observe the
          * {@link $notLoggedin $notLoggedin} or {@link $currentUser $currentUser}
          * events.  They are emitted when this method has a success or failure.
          *
          * The user object is a Stormpath Account
-         * object which is wrapped by by a {@link eh User} type
+         * object, which is wrapped by a {@link eh User} type.
          *
-         * @returns {promise} A promise representing the operation to get the current user data
+         * @returns {promise}
+         *
+         * A promise representing the operation to get the current user data.
          *
          * @example
+         *
          * <pre>
          * var myApp = angular.module('myApp', ['stormmpath']);
          *
@@ -1551,15 +1607,17 @@ angular.module('stormpath.userService',['stormpath.CONFIG'])
          * @name stormpath.userService.$user#$currentUser
          * @eventOf stormpath.userService.$user
          * @eventType broadcast on root scope
+         *
          * @description
+         *
          * This event is broadcast when a call to
          * {@link stormpath.userService.$user#methods_get $user.get()}
-         * results in a {@link User User} object
+         * results in a {@link User User} object.
          *
-         * See the next section, the $notLoggeInEvent, for example usage
+         * See the next section, the $notLoggeInEvent, for example usage.
          *
          * @param {Object} event Angular event object.
-         * @param {User} user The current user object
+         * @param {User} user The current user object.
          *
          */
         $rootScope.$broadcast(STORMPATH_CONFIG.GET_USER_EVENT,user);
@@ -1570,30 +1628,34 @@ angular.module('stormpath.userService',['stormpath.CONFIG'])
          * @name stormpath.userService.$user#$notLoggedIn
          * @eventOf stormpath.userService.$user
          * @eventType broadcast on root scope
+         *
          * @description
+         *
          * This event is broadcast when a call to
          * {@link stormpath.userService.$user#methods_get $user.get()}
-         * results in an authentication failure
+         * results in an authentication failure.
          *
          * This event is useful for situations where you want to trigger
          * the call to get the current user, but need to respond to it
-         * from some other place in your application.  An example could be
-         * during application bootstrap: you make a single call to get the current
+         * from some other place in your application.  An example could be,
+         * during application bootstrap, you make a single call to get the current
          * user from the run function, then react to it inside your
          * application controller.
          *
          * @param {Object} event Angular event object.
          *
          * @example
+         *
          * <pre>
          * var myApp = angular.module('myApp', ['stormmpath']);
          * myApp.run(function($user){
          *   //
-         *   // Once our app is ready to run, trigger a call to $user.get()
-         *   // We can then do other things while we wait for the result
+         *   // Once our app is ready to run, trigger a call to $user.get().
+         *   // We can then do other things while we wait for the result.
          *   //
          *   $user.get();
          * });
+         *
          * myApp.controller('MyAppCtrl', function ($scope, $rootScope) {
          *   $scope.isVisible = false; // Wait for authentication
          *   $rootScope.$on('$notLoggedIn',function(){

--- a/docs/source/access_control.rst
+++ b/docs/source/access_control.rst
@@ -36,7 +36,7 @@ Helper Directives
 
 If you need to show or hide specific elements in response to group state,
 you can use the `ifUserInGroup`_ and `ifUserNotInGroup`_ directives. In
-this example, we show a link to the Admin view, if the user is in the admin
+this example, we show a link to the Admin view if the user is in the admin
 group.  If the user is not in the Admin group, we let them know that they
 need to request access::
 
@@ -60,7 +60,7 @@ API Security
 
 Don't forget to secure your API!  While we provide these convenience
 methods in Angular, you need to protect your server APIs as well.
-If you are using our Express SDK you can use the `groupsRequired Middleware`_
+If you are using our Express SDK, you can use the `groupsRequired Middleware`_
 to help with this.
 
 

--- a/docs/source/coming_soon.rst
+++ b/docs/source/coming_soon.rst
@@ -5,7 +5,7 @@ Coming Soon!
 
 *Last Update: April 2nd, 2015*
 
-Now that you've reached the end of this tutorial, you have a brannd new
+Now that you've reached the end of this tutorial, you have a brand new
 Angular application - complete with a user registration and login system!
 
 AngularJS is really important to us and we're developing our features

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@ import os
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.0'
 
-# Add any Sphinx extension module names here, as strings. They can be
+# Add any Sphinx extension module names here as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = []

--- a/docs/source/configure_angular.rst
+++ b/docs/source/configure_angular.rst
@@ -47,8 +47,8 @@ from the config block to the run block)::
 
 This tells the integration to do the following:
 
-* Redirect users to the ``login`` view if they try to access a restricted view. After login, they are sent back to the view that they originally requested
-* Send users to the ``main`` view after login, if they have visited the login page directly (they did not try to access a restricted view first)
+* Redirect users to the ``login`` view if they try to access a restricted view. After login, they are sent back to the view that they originally requested.
+* Send users to the ``main`` view after login, if they have visited the login page directly (they did not try to access a restricted view first).
 
 With that we can move to the next section and create a Registration Form, so that
 users can sign up for our service.

--- a/docs/source/create_new_project.rst
+++ b/docs/source/create_new_project.rst
@@ -25,7 +25,7 @@ repeatable boilerplate code).  This must also be installed as a global NPM packa
 
     $ npm install -g yo
 
-Finally we will install `Bower`_, a package manager for front-end applications::
+Finally, we will install `Bower`_, a package manager for front-end applications::
 ::
 
     $ npm install -g bower
@@ -43,7 +43,7 @@ Create an Angular-fullstack project
 ------------------------------------
 
 We are going to use the `Angular Fullstack Generator <https://github.com/DaftMonk/generator-angular-fullstack>`_.
-It's going to create a LOT of files for us: essentially, our entire devopment environment
+It's going to create a LOT of files for us: essentially, our entire development environment
 and the seed files for the client AND server.  This is really amazing.
 
 To use the generator you need to first install it as a global node module::
@@ -55,13 +55,13 @@ At this point you should create a directory for your project and change into it:
     $ mkdir my-angular-project && cd $_
 
 Once there we use the generator to create the project.  We need to give our application a
-name (it does not have to be the same as the folder).  Since we are budilng a basic user
-dashboard for our API we will call it dashboard::
+name (it does not have to be the same as the folder).  Since we are building a basic user
+dashboard for our API, we will call it dashboard::
 
     $ yo angular-fullstack dashboard-app
 
 The generator will ask you several questions, such as which templating engine to use.  We're sticking
-to vanilla HTML/CSS/JS for this guide, the only opinionated choice we are making is to the the 3rd-party
+to vanilla HTML/CSS/JS for this guide. The only opinionated choice we are making is to the the 3rd-party
 `UI Router`_ instead of Angular's default.
 Here are the choices that we made::
 
@@ -113,7 +113,7 @@ this command to get the latest::
 
     $ npm i express@latest --save
 
-In the next section we will get your Stormpath Tenant information, so that we can
+In the next section, we will get your Stormpath Tenant information, so that we can
 continue with the latter sections.
 
 .. _Stormpath Admin Console: https://api.stormpath.com

--- a/docs/source/create_tenant.rst
+++ b/docs/source/create_tenant.rst
@@ -11,7 +11,7 @@ Sign up for Stormpath
 ---------------------
 
 Now that you're ready to integrate Stormpath, the first thing you'll want to do is
-create a new Stormpath account by visiting https://api.stormpath.com/register
+create a new Stormpath account by visiting https://api.stormpath.com/register.
 
 We'll send you an email verification message, please verify it and then you can
 login to the `Stormpath Admin Console`_.

--- a/docs/source/customize_menu.rst
+++ b/docs/source/customize_menu.rst
@@ -14,7 +14,7 @@ When the user is not logged in, we want the following to happen:
 But when they login, we want the following to happen:
 
  * Hide the links to the Registration and Login pages
- * Show a link to the Profile page (we'll build that in a later secion)
+ * Show a link to the Profile page (we'll build that in a later section)
  * Show a Logout link
 
 Modify navbar.html
@@ -59,5 +59,5 @@ After you save the file the browser should reload and you'll see the
 changes to the menu bar.  Click on the Logout button - you should see
 that the menu bar changes to show that you're no longer logged in.
 
-In the next section we're going to build the Login route, so that you
+In the next section, we're going to build the Login route, so that you
 can log back in!

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -8,12 +8,12 @@ We will be starting a new project from scratch, we will use the Grunt
 and Yeoman tools to take care of the tedious setup.
 
 If you're a seasoned AngularJS developer and simply need to know the
-module API you can visit the `Stormpath AngularJS SDK API Documenation <https://docs.stormpath.com/angularjs/sdk/>`_.
-Throughout this guide we will refer you to the API documenation if you want
+module API, you can visit the `Stormpath AngularJS SDK API Documentation <https://docs.stormpath.com/angularjs/sdk/>`_.
+Throughout this guide, we will refer you to the API documentation if you want
 to learn more about how we're using it.
 
 While this guide will be JavaScript only, we do have support in our Java
-SDK for thes same features.  If you are using Java please see our `Java Web App Plugin Guide`_.
+SDK for the same features.  If you are using Java, please see our `Java Web App Plugin Guide`_.
 
 .. _Java Web App Plugin Guide: https://docs.stormpath.com/java/servlet-plugin/
 
@@ -24,16 +24,16 @@ What we're building
 
 Let's quickly cover what we'll be building:
 
-**A fullstack project**.  We're going to create a project with a lot of boilerplate code, but don't worry: it's going to be created automatically for you!  This is the power of Yeoman
+**A fullstack project**.  We're going to create a project with a lot of boilerplate code, but don't worry: it's going to be created automatically for you!  This is the power of Yeoman.
 
-**A Node.js server**. This server will serve the assets for the AngularJS application.  It will also serve a simple API which we will secure with Stormpath
+**A Node.js server**.  This server will serve the assets for the AngularJS application.  It will also serve a simple API, which we will secure with Stormpath.
 
-**An AngularJS application**.  This will be an HTML5-based application which allows users to register, login, and see their profile.  We will control profile access so that only logged-in users can access that view.
+**An AngularJS application**.  This will be an HTML5-based application, which allows users to register, login, and see their profile.  We will control profile access, so that only logged-in users can access that view.
 
 
 How to get support
 -------------------
-Getting stuck?  Stormpath is a developer-focused platform, we want to hear from you!  Reach
+Getting stuck?  Stormpath is a developer-focused platform.  We want to hear from you!  Reach
 us anytime through one of the following channels:
 
 * Email support: support@stormpath.com

--- a/docs/source/login.rst
+++ b/docs/source/login.rst
@@ -5,7 +5,7 @@ Create the Login form
 
 Login forms are pretty straightforward, why re-invent the wheel?
 The Stormpath Angular SDK includes a default login form that you can
-simply insert into your application.  In the next release of this guide
+simply insert into your application.  In the next release of this guide,
 we will show you how to add password reset functions to this form, see
 :ref:`coming_soon`
 
@@ -40,24 +40,24 @@ it's contents with this::
 
 This is a small bit of HTML markup which does the following:
 
-* Includes the common menu bar for the application (we customized it in the last section)
-* Sets up some Bootstrap classes so that the page flows nicely
-* Inserts the default login form, via the `spLoginForm <https://docs.stormpath.com/angularjs/sdk/#/api/stormpath.spLoginForm:sp-login-form>`_ directive
+* Includes the common menu bar for the application (we customized it in the last section).
+* Sets up some Bootstrap classes so that the page flows nicely.
+* Inserts the default login form, via the `spLoginForm <https://docs.stormpath.com/angularjs/sdk/#/api/stormpath.spLoginForm:sp-login-form>`_ directive.
 
-Save that file and the browser should auto reload, you should now
+Save that file and the browser should auto reload. You should now
 see the login route like this:
 
 .. image:: _static/login_form.png
 
 
 If you want to further customize the look and behaviour of the form,
-please see the API documentation of for
+please see the API documentation for
 `spLoginForm <https://docs.stormpath.com/angularjs/sdk/#/api/stormpath.spLoginForm:sp-login-form>`_ directive.
 The most useful feature is the ability to specify your own template.
 
 Try it, log back in!
 --------------------------------
 
-Submit the username and password that you created when you registered,
-you should be redirected back to the main view and you should see the
+Submit the username and password that you created when you registered.
+You should be redirected back to the main view, and you should see the
 logged-in changes to the menu bar.

--- a/docs/source/password_reset.rst
+++ b/docs/source/password_reset.rst
@@ -5,21 +5,21 @@ Password Reset Flow
 
 Stormpath has your back when it comes to password reset!  We have
 a complete, secure solution that allows your users to request a password
-reset by email.  We send the user a link with a verification token, when
+reset by email.  We send the user a link with a verification token; when
 they click on this link they arrive back at your site.  You then validate
 that this token came from us, and allow the user to set a new password.
 We do all the heavy lifting for you!
 
 We are going to create two separate UI routes for this flow:
 
-* ``/password/requestReset`` will serve a form which alllows the user to ask for a new email.
+* ``/password/requestReset`` will serve a form, which allows the user to ask for a new email.
 * ``/password/reset`` will be the page they land on when they click on the link in their email.
 
 
 Generate the routes
 --------------------------------
 
-Using the generator command, create a route named ``passwordResetRequest`` but make sure
+Using the generator command, create a route named ``passwordResetRequest``, but make sure
 that you set the URL to ``/password/requestReset`` when prompted.  We will use this
 route to render a form which asks them for their email address::
 
@@ -32,7 +32,7 @@ route to render a form which asks them for their email address::
        create client/app/passwordResetRequest/passwordResetRequest.css
        create client/app/passwordResetRequest/passwordResetRequest.html
 
-Then we want to make a form which allows them to set a new password, after we verify
+Then we want to make a form which allows them to set a new password after we verify
 that they have arrived with a valid reset token.  We will name this view ``passwordReset``
 and give it a URL of ``/password/reset`` - make sure to set this when prompted::
 
@@ -94,7 +94,7 @@ Next find `client/app/passwordResetRequest/passwordResetRequest.html` and replac
 Configure the Directory
 ------------------------------------
 
-In order to use the password reset feature you will need to enable it
+In order to use the password reset feature, you will need to enable it
 on the Directory that this account will be created in.  Login to the
 `Stormpath Admin Console`_ and find the Directories tab.  You will see the
 Directory that was automatically created for the Application.  Click into it,

--- a/docs/source/protect_api.rst
+++ b/docs/source/protect_api.rst
@@ -3,7 +3,7 @@
 Secure the API
 ====================
 
-The project generator created a simple API for us, it is an Express.js application.
+The project generator created a simple API for us. It is an Express.js application.
 It serves a list of things at ``/api/things`` (you saw this when you ran ``grunt serve`` for the first time,
 they were listed on the home page of the application).  We will use Stormpath to secure this simple API
 
@@ -14,7 +14,7 @@ In the last section, :ref:`create_tenant`, we gathered our API keys an Applicati
 
 We need to place this information somewhere, so that our Express server can make use of it
 This generator follows a convention: whatever is listed in ``server/config/local.env.js`` will
-be automaticaly exposed to the environment.  Open that file and add these properties to the
+be automatically exposed to the environment.  Open that file, add these properties to the
 export block, and fill in your values::
 
     module.exports = {
@@ -33,18 +33,18 @@ Grunt will automatically export these values to the environment, and the Stormpa
 Add the Stormpath middleware
 ---------------------------
 
-Find the file ``server/routes.js``
+Find the file ``server/routes.js``.
 
-This file is attaching some routes to the Express application that is setup in ``server/app.js``
+This file is attaching some routes to the Express application that is setup in ``server/app.js``.
 
-We want to initialize the Stormpath middleware and add it before our API declarion, so that the API will be automatically protected.
+We want to initialize the Stormpath middleware and add it before our API declaration, so that the API will be automatically protected.
 
 First things first, you need to require the SDK - place this at the top of the file::
 
     var stormpathExpressSdk = require('stormpath-sdk-express');
 
 Then you want to create an instance of the Stormpath middleware.  You can
-pass options, but in our case we are just going to make a simple call and
+pass options, but in our case, we are just going to make a simple call and
 use all the default options.  Add this line before the ``module.exports`` statement::
 
     var spMiddleware = stormpathExpressSdk.createMiddleware();
@@ -76,4 +76,4 @@ in your browser:
 .. image:: _static/features-unauthorized.png
 
 
-Our API is now protected from unauthorized, anonymous access.  In the next two sections we will show you how to create a registration form and a login form.  At that point you will be able to login and have access to the API.
+Our API is now protected from unauthorized, anonymous access.  In the next two sections, we will show you how to create a registration form and a login form.  At that point, you will be able to login and have access to the API.

--- a/docs/source/register.rst
+++ b/docs/source/register.rst
@@ -4,12 +4,12 @@ Create the Registration Form
 ===================
 
 We want our users to sign up for our service, so we need to provide a Registration
-form.  The Stormpath Angular SDK provides a pre-built registration form, we're
+form.  The Stormpath Angular SDK provides a pre-built registration form and we're
 going to show you how to use it.  When a user submits this form, it will create a new
 account for them in the Stormpath Directory that is associated with the Stormpath Application
 that you created in the :ref:`create_tenant` section
 
-Generate the /register route
+Generate the /register Route
 --------------------------------
 
 When you want to create a new route and view in an Angular application, there
@@ -31,7 +31,7 @@ It will ask you some questions, just hit enter to choose the defaults for all of
        create client/app/register/register.html
 
 Start the server and then manually type in the URL to ``/register``
-in your browser, you will see the default view that was created:
+in your browser. You will see the default view that was created:
 
 
 .. image:: _static/default-register-view.png
@@ -40,7 +40,7 @@ Use the Registration Form Directive
 -----------------------------------
 
 We're going to take advantage of the default registration form
-that is available to you in the Stormpath Angular SDK
+that is available to you in the Stormpath Angular SDK.
 
 Open the file ``client/app/register/register.html`` and then replace
 it's contents with this::
@@ -59,22 +59,22 @@ it's contents with this::
 
 This is a small bit of HTML markup which does the following:
 
-* Includes the common menu bar for the application (we will customize it the next section)
-* Sets up some Bootstrap classes so that the page flows nicely
-* Inserts the default registration form, via the ``sp-registration-form`` directive
-* Declares (on the directive) that we want to send the user to the main page after they register
+* Includes the common menu bar for the application (we will customize it the next section).
+* Sets up some Bootstrap classes so that the page flows nicely.
+* Inserts the default registration form via the ``sp-registration-form`` directive.
+* Declares (on the directive) that we want to send the user to the main page after they register.
 
-Save that file and the browser should auto reload, you should now
+Save that file, and the browser should auto reload. You should now
 see the registration route like this:
 
 .. image:: _static/registration_form.png
 
 If you want to further customize the look and behaviour of the form,
-please see the API documentation of for
-`sp-registration-frorm <https://docs.stormpath.com/angularjs/sdk/#/api/stormpath.spRegistrationForm:sp-registration-form>`_.
+please see the API documentation for
+`sp-registration-form <https://docs.stormpath.com/angularjs/sdk/#/api/stormpath.spRegistrationForm:sp-registration-form>`_.
 The most useful feature is the ability to specify your own template.
 
-Generate the /register/verify route
+Generate the /register/verify Route
 --------------------------------
 
 The `Stormpath Email Verification`_ feature will allow you to confirm a user's
@@ -82,12 +82,12 @@ identity by sending them a link that they must click on.
 We handle all the email and links for you!  (If you don't want to use this
 feature, you can skip this section).
 
-However we must decide where the user should go when they click on that
+However, we must decide where the user should go when they click on that
 link in their email.  We will implement a default view for this in our application
 and configure the Stormpath Directory accordingly.
 
-The first thing is to generate another route.  In this situation we will
-call the controller ``emailVerification`` but use the URL of ``/register/verify``
+The first thing is to generate another route.  In this situation, we will
+call the controller ``emailVerification``, but use the URL of ``/register/verify``.
 ::
 
   $ yo angular-fullstack:route emailVerification
@@ -99,7 +99,7 @@ call the controller ``emailVerification`` but use the URL of ``/register/verify`
      create client/app/emailVerification/emailVerification.css
 
 
-Add the sptoken parameter
+Add the sptoken Parameter
 --------------------------------
 
 When the user clicks on the link in their email, they will be sent to your
@@ -115,11 +115,11 @@ Use the Email Verification Directive
 ------------------------------------
 
 We have a pre-built view that shows the necessary informational
-messages when someome is trying to complete the email verification process.
+messages when someone is trying to complete the email verification process.
 It will:
 
-* Show a success message and prompt them to login
-* Allow them to request another email if the links has expired
+* Show a success message and prompt them to login.
+* Allow them to request another email if the links has expired.
 
 Open the file ``client/app/emailVerification/emailVerification.html`` and
 replace it's contents with the following::
@@ -139,7 +139,7 @@ replace it's contents with the following::
 Configure the Directory
 ------------------------------------
 
-In order to use the email verification feature you will need to enable it
+In order to use the email verification feature, you will need to enable it
 on the Directory that this account will be created in.  Login to the
 `Stormpath Admin Console`_ and find the Directories tab.  You will see the
 Directory that was automatically created for the Application.  Click into it,
@@ -156,15 +156,15 @@ Here is what that screen looks like:
 
 .. image:: _static/directory_email_verification.png
 
-Try it, register for an account!
+Try It, Register for an Account!
 --------------------------------
 
 That's it, really!  Give the form a try.  Once you register for an
-account you will be automatically redirected back to the main page.
+account, you will be automatically redirected back to the main page.
 You will also be logged in automatically, and you will start seeing
 the list of things again - remember how we locked it down?  Now that
-you are authenticated you are allowed to access that part of the API
-again
+you are authenticated, you are allowed to access that part of the API
+again.
 
 Customizing The Form
 ----------------------
@@ -183,17 +183,17 @@ into it.  Then add the following markup to it, in a place that you like::
     </div>
   </div>
 
-Now modify your registration form directive, telling it to use this custom template::
+Now, modify your registration form directive and tell it to use this custom template::
 
   <div sp-registration-form post-login-state="main" template-url="app/register/my-register.html"></div>
 
-You registration form should have a new field for entering your favorite color!  This information
+Your registration form should have a new field for entering your favorite color!  This information
 will go into the ``customData`` object on the Account object.
 
 .. note::
   You need to ensure that your server-side framework is decoding complex form
-  objects.  In our Yeoman example you will need to open ``sever/config/express.js``
-  and moodify this line to enable that option::
+  objects.  In our Yeoman example, you will need to open ``sever/config/express.js``
+  and modify this line to enable that option::
 
     app.use(bodyParser.urlencoded({ extended: true }));
 

--- a/docs/source/user_profile.rst
+++ b/docs/source/user_profile.rst
@@ -3,12 +3,12 @@
 Creating a User Profile View
 =========================
 
-Most user-centric application have a Profile view, where the user can view and
-edit their basic profile information.  In this section we will show you how to
+Most user-centric applications have a Profile view where the user can view and
+edit their basic profile information.  In this section, we will show you how to
 make a *very* simple display of the user's information.  In the next release of
-this guide we will show you how to update the user's information, see :ref:`coming_soon`
+this guide, we will show you how to update the user's information, see :ref:`coming_soon`
 
-Generate the /profile route
+Generate the /profile Route
 -----------------
 
 Alright, one more time!  We're going to use the generator to scaffold the files for us::
@@ -16,11 +16,11 @@ Alright, one more time!  We're going to use the generator to scaffold the files 
     $ yo angular-fullstack:route profile
 
 
-Force authentication
+Force Authentication
 ---------------------
 
-The user must be logged in if they wan't to see their profile,
-otherwise there is nothing to show!  We want to prevent users
+The user must be logged in if they want to see their profile;
+otherwise, there is nothing to show!  We want to prevent users
 from accessing this page if they are not logged in.  We do
 that by defining the
 `SpStateConfig <https://docs.stormpath.com/angularjs/sdk/#/api/stormpath.SpStateConfig:SpStateConfig>`_
@@ -38,23 +38,23 @@ state configuration to include the Stormpath state configuration::
       }
     });
 
-Create the view
+Create the View
 ------------------
 
 Because we have declared ``authenticate: true`` for this state, we
-are guranteed that the user will always be logged in by the time that
+are guaranteed that the user will always be logged in by the time that
 this view loads (if the user is not logged in, they are redirected
 to the login page - and then back here).
 
-With that assurance we can code our template without any complex
+With that assurance, we can code our template without any complex
 switches.
 The Stormpath module will automatically assign the current user
 object to ``user`` on the Root Scope, so it will always be available
 in your templates.
 
-We're gonna keep this super simple and merely render user's object as a JSON
-structure.  Obviously you'll be doing more than this when your application goes
-live :)
+We're going to keep this super simple and merely render user's object as a JSON
+structure.  Obviously, you'll be doing more than this when your application goes
+live. :)
 
 Open the file ``client/app/profile/profile.html`` and then replace
 it's contents with this::
@@ -81,7 +81,7 @@ Just like the other pages, we've included our common menu and setup
 some basic Bootstrap classes.  The ``<pre>`` block will leverage
 Angular's built-in ``json`` filter to show the user object.
 
-Try it out, see your profile!
+Try It Out, See Your Profile!
 -----------------------------
 
 Go back to your browser, make sure your logged in and then go to the

--- a/docs/source/wait_for_user.rst
+++ b/docs/source/wait_for_user.rst
@@ -6,22 +6,22 @@ Waiting For User State
 Now that we have a complete application, you should play around with it!
 
 As you do, you may find something annoying:  our menu bar has a bit of
-a "flash" to it: even if we are logged in, it will momentarily show
+a "flash" to it; even if we are logged in, it will momentarily show
 as if we are not logged in.  This happens while we're fetching the information
 about the current user.
 
-You'll only see this on the main view, you won't see it on the Profile
+You'll only see this on the main view; you won't see it on the Profile
 view because that is an authenticated route.
 
 How do we solve this problem?
 
-Use the waitForUser option
+Use the waitForUser Option
 ---------------------------
 
-The anwer is incredibly simple, just use the ``waitForUser`` option on
+The answer is incredibly simple. Just use the ``waitForUser`` option on
 the state configuration!
 
-With this option we will defer the rendering of the view, but won't
+With this option, we'll defer the rendering of the view, but won't
 go to the login page if the user is not logged in.  We'll continue to
 the view, but the current user state will be resolved either way.  This
 allows our templates to render properly and immediately once the state

--- a/ngdoc_assets/index.ngdoc
+++ b/ngdoc_assets/index.ngdoc
@@ -8,8 +8,8 @@
 
 ## Welcome!  Let's get started
 
-You are reading the API documentation for the Stormpath AngularJS SDK,
-you are moments away from adding user login features to your Angular application :)
+You are reading the API documentation for the Stormpath AngularJS SDK
+and are moments away from adding user login features to your Angular application. :)
 
 If you're ready to dive in with code, see the [Getting Started](#quickstart) section.
 
@@ -18,7 +18,7 @@ If you want a walkthrough tutorial, see the [In-Depth Guide](https://docs.stormp
 
 ## Overview
 
-Used in conjuction with Stormpath on your backend, this module provides
+Used in conjunction with Stormpath on your backend, this module provides
 Angular services which allow you to:
 
 * Authenticate username & password and get the Account object
@@ -31,10 +31,10 @@ Angular services which allow you to:
 
 This module is intended to be used with a Stormpath SDK on your server.  Our
 [Stormpath Express SDK][stormpath-sdk-express] is specifically designed for this.
-We support many other langues as well, please see [docs.stormpath.com]
+We support many other languages as well, please see [docs.stormpath.com]
 
-By default the Angular application expects to find the `/oauth/token` and
-`/api/users/current` endpoints.  If you need to use alternate URLs you can
+By default, the Angular application expects to find the `/oauth/token` and
+`/api/users/current` endpoints.  If you need to use alternate URLs, you can
 configure them using the {@link $stormpath} provider.
 
 ## Using with Express.js
@@ -42,35 +42,35 @@ configure them using the {@link $stormpath} provider.
 We have an Express-based example application in the github repo for
 this project, see the <a href="#example">Example</a>
 
-## How token authentication works
+## How Token Authentication Works
 
 We have written a comprehensive article about token authentication for
 Single Page Applications (SPAs).  Please find it here:
 
 <a href="https://stormpath.com/blog/token-auth-spa" target="_blank">https://stormpath.com/blog/token-auth-spa</a>
 
-### Token creation and storage
+### Token Creation and Storage
 
-When a user logs in the server will issue an access token in the form of a
-JWT.  This access token will be stored in an HTTP-only cookie, and will also
+When a user logs in ,the server will issue an access token in the form of a
+JWT.  This access token will be stored in an HTTP-only cookie and will also
 set the Secure flag (so that it is only sent over HTTPS) in your production
 environment.
 
-You may have heard that cookie are insecure, but that is a vague statement.
-The truth is that HTTP-only cookies, espeically Secure-only cookies, are the
-most secure place to store authentication information becuase the Javascript
+You may have heard that cookies are insecure, but that is a vague statement.
+The truth is that HTTP-only cookies, especially Secure-only cookies, are the
+most secure place to store authentication information because the Javascript
 environment cannot access them.  This is the best way to protect yourself
 from XSS attacks.
 
-### Token expiration and revocation
+### Token Expiration and Revocation
 
 Access tokens are valid until they expire.  You should set an expiration (TTL) that
 makes sense for your application.  The TTL is controlled on your server.  If you
-are using the [Stormpath Express SDK][stormpath-sdk-express] you want to
+are using the [Stormpath Express SDK][stormpath-sdk-express], you want to
 configure the `accessTokenTtl` options.
 
-If you need the ability to revoke specific tokens you can maintain a cache of issued
-tokens on your server.  All tokens have a `jti` field which is a unique nonce for each token.
+If you need the ability to revoke specific tokens, you can maintain a cache of issued
+tokens on your server.  All tokens have a `jti` field, which is a unique nonce for each token.
 
 [docs.stormpath.com]: https://docs.stormpath.com
 [ui-router]: https://github.com/angular-ui/ui-router

--- a/ngdoc_assets/quickstart/index.ngdoc
+++ b/ngdoc_assets/quickstart/index.ngdoc
@@ -24,7 +24,7 @@
 
  ## Configuration
 
- You will need to add `stormpath` as a depenency of your Angular application,
+ You will need to add `stormpath` as a dependency of your Angular application
  and the templates if you will be using those:
 
  <pre>
@@ -35,12 +35,12 @@
 
  ## Templates are optional
 
- This libray includes some default view templates for forms, such as
+ This library includes some default view templates for forms, such as
  registration and login.  You have the option to specify your own templates
  for those directives.  If you are using your own templates it does not make
  sense to include our defaults.
 
- If you are using the manual installation: sipmply remove the file
+ If you are using the manual installation: simply remove the file
  `stormpath-sdk-angularjs.tpls.min.js`
 
  If you are using Bower, you can specify an override for this module

--- a/src/module.js
+++ b/src/module.js
@@ -9,13 +9,13 @@
  *
  * ## Welcome!  Let's get started
  *
- * You are reading the API documentation for the Stormpath AngularJS SDK,
- * you are moments away from sovling all kinds of user management issues
- * in your Angular application :)
+ * You are reading the API documentation for the Stormpath AngularJS SDK
+ * and are moments away from solving all kinds of user management issues
+ * in your Angular application. :)
  *
  * ## Installation - Bower
  *
- * If you are using [Bower](https://bower.io) you can simply install
+ * If you are using [Bower](https://bower.io), you can simply install
  * our package:
  *
  * ```
@@ -25,8 +25,8 @@
  * ## Installation - Manual
  *
  * If you would like to add the scripts manually, simply get the latest files from
- * the [dist folder on github](https://github.com/stormpath/stormpath-sdk-angularjs/tree/master/dist).
- * Then add them to the `<head>` section of your document:
+ * the [dist folder on github](https://github.com/stormpath/stormpath-sdk-angularjs/tree/master/dist),
+ * then add them to the `<head>` section of your document:
  *
  * <pre>
  * <script src="stormpath-sdk-angularjs.min.js"></script>
@@ -35,7 +35,7 @@
  *
  * ## Configuration
  *
- * You will need to add `stormpath` as a depenency of your Angular application,
+ * You will need to add `stormpath` as a dependency of your Angular application,
  * and the templates if you will be using those:
  *
  * <pre>
@@ -46,12 +46,12 @@
  *
  * ## Templates are optional
  *
- * This libray includes some default view templates for forms, such as
+ * This library includes some default view templates for forms, such as
  * registration and login.  You have the option to specify your own templates
- * for those directives.  If you are using your own templates it does not make
+ * for those directives.  If you are using your own templates, it does not make
  * sense to include our defaults.
  *
- * If you are using the manual installation: sipmply remove the file
+ * If you are using the manual installation, simply remove the file
  * `stormpath-sdk-angularjs.tpls.min.js`
  *
  * If you are using Bower, you can specify an override for this module
@@ -77,20 +77,26 @@
  * @ngdoc object
  * @name stormpath.SpStateConfig:SpStateConfig
  * @description
+ *
  * The Stormpath State Config is an object that you can define on a
- * state.  You will need to be using the UI Router module, and you need
+ * state.  You will need to be using the UI Router module and you need
  * to enable the integration by calling  {@link stormpath.$stormpath#methods_uiRouter $stormpath.uiRouter()}
- * @property {boolean} authenticate If `true`, the user must be
- * authenticated in order to view this state.  If the user is not authenticated they will
- * be redircted to the `login` state.  After they login they will be redicted to
+ *
+ * @property {boolean} authenticate
+ *
+ * If `true`, the user must be
+ * authenticated in order to view this state.  If the user is not authenticated, they will
+ * be redirected to the `login` state.  After they login, they will be redirected to
  * the state that was originally requested.
  *
  * @property {object} authorize
  *
- * An object which defines access control rules.  Currently is supports a group-based
- * check.  See the example below
+ * An object that defines access control rules.  Currently, it supports a group-based
+ * check.  See the example below.
  *
- * @property {boolean} waitForUser If `true`, delay the state transition until we know
+ * @property {boolean} waitForUser
+ *
+ * If `true`, delay the state transition until we know
  * if the user is authenticated or not.  This is useful for situations where
  * you want everyone to see this state, but the state may look different
  * depending on the user's authentication state.
@@ -102,7 +108,7 @@
  * angular.module('myApp')
  *   .config(function ($stateProvider) {
  *
- *     // Wait until we know if the user is logged in, before showing the homepage
+ *     // Wait until we know if the user is logged in before showing the homepage
  *     $stateProvider
  *       .state('main', {
  *         url: '/',
@@ -140,7 +146,9 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
   /**
    * @ngdoc object
    * @name stormpath.$stormpath
+   *
    * @description
+   *
    * This service allows you to enable application-wide features of the library.
    */
 
@@ -206,26 +214,29 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
        * @ngdoc function
        * @name stormpath#uiRouter
        * @methodOf stormpath.$stormpath
+       *
        * @description
+       *
        * Call this method to enable the integration with the UI Router module.
        *
-       * When enabled you can define {@link stormpath.SpStateConfig:SpStateConfig Stormpath State Configurations} on your UI states, this
-       * object allows you to define access control for the state.  See the
-       * examples below
+       * When enabled, you can define {@link stormpath.SpStateConfig:SpStateConfig Stormpath State Configurations} on your UI states.
+       * This object allows you to define access control for the state.  See the
+       * examples below.
        *
        * @param {object} config
-       * * **`loginState`** - The UI state name that we should send the user
-       * to if they need to login.  You'll probably use `login` for this value
        *
-       * * **`autoRedirect`** - Defaults to true.  After the user logins at
-       * the state defined by `loginState` they will be redirected back to the
-       * state that was originally requested
+       * * **`loginState`** - The UI state name that we should send the user
+       * to if they need to login.  You'll probably use `login` for this value.
+       *
+       * * **`autoRedirect`** - Defaults to true.  After the user logs in at
+       * the state defined by `loginState`, they will be redirected back to the
+       * state that was originally requested.
        *
        * * **`defaultPostLoginState`**  - Where the user should be sent, after login,
        * if they have visited the login page directly.  If you do not define a value,
        * nothing will happen at the login state.  You can alternatively use the
        * {@link stormpath.authService.$auth#events_$authenticated $authenticated} event to know
-       * that login is successful
+       * that login is successful.
        *
        * @example
        * <pre>
@@ -377,7 +388,8 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
  * @name stormpath.ifUser:ifUser
  *
  * @description
- * Use this directive to conditionally show an element, if the user is logged in.
+ *
+ * Use this directive to conditionally show an element if the user is logged in.
  *
  * @example
  * <pre>
@@ -405,9 +417,11 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
  * @name stormpath.ifNotUser:ifNotUser
  *
  * @description
- * Use this directive to conditionally show an element, if the user is NOT logged in.
+ *
+ * Use this directive to conditionally show an element if the user is NOT logged in.
  *
  * @example
+ *
  * <pre>
  * <div class="container">
  *   <h3 if-not-user>Hello, you need to login</h3>
@@ -433,10 +447,12 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
  * @name stormpath.ifUserInGroup:ifUserInGroup
  *
  * @description
+ *
  * Use this directive to conditionally show an element if the user is logged in
- * and is a member of the group that is specified by the string
+ * and is a member of the group that is specified by the string.
  *
  * @example
+ *
  * <pre>
  * <div class="container">
  *   <h3 if-user-in-group="admins">Hello, {{user.fullName}}, you are an administrator</h3>
@@ -462,10 +478,12 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
  * @name stormpath.ifUserNotInGroup:ifUserNotInGroup
  *
  * @description
+ *
  * Use this directive to conditionally show an element if the user is logged in
- * and is a member of the group that is specified by the string
+ * and is a member of the group that is specified by the string.
  *
  * @example
+ *
  * <pre>
  * <div class="container">
  *   <h3 if-user-not-in-group="admins">Hello, {{user.fullName}}, please request administrator access</h3>
@@ -491,6 +509,7 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
  * @name stormpath.whileResolvingUser:while-resolving-user
  *
  * @description
+ *
  * # [DEPRECATED]
  * Please use {@link stormpath.ifUserStateUnknown:ifUserStateUnknown ifUserStateUnknown} instead
  *
@@ -513,12 +532,14 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
  * @name stormpath.ifUserStateKnown:ifUserStateKnown
  *
  * @description
+ *
  * Use this directive to show an element once the user state is known.
- * The inverse of {@link stormpath.ifUserStateUnknown:ifUserStateUnknown ifUserStateUnknown}, you can
+ * The inverse of {@link stormpath.ifUserStateUnknown:ifUserStateUnknown ifUserStateUnknown}. You can
  * use this directive to show an element after we know if the user is logged in
  * or not.
  *
  * @example
+ *
  * <pre>
  * <div if-user-state-known>
  *   <li if-not-user>
@@ -548,11 +569,13 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
  * @name stormpath.ifUserStateUnknown:ifUserStateUnknown
  *
  * @description
- * Use this directive to show an element, while waiting to know if the user
+ *
+ * Use this directive to show an element while waiting to know if the user
  * is logged in or not.  This is useful if you want to show a loading graphic
  * over your application while you are waiting for the user state.
  *
  * @example
+ *
  * <pre>
  * <div if-user-state-unknown>
  *   <p>Loading.. </p>
@@ -578,9 +601,11 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
  * @name stormpath.spLogout:spLogout
  *
  * @description
- * This directive adds a click handler to the element.  When clicked the user will be logged out.
+ *
+ * This directive adds a click handler to the element.  When clicked, the user will be logged out.
  *
  * @example
+ *
  * <pre>
  *   <a ui-sref="main" sp-logout>Logout</a>
  * </pre>

--- a/src/spPasswordResetRequestForm.tpl.html
+++ b/src/spPasswordResetRequestForm.tpl.html
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="col-sm-offset-4 col-xs-12 col-sm-4">
     <p ng-show="sent" class="alert alert-success">
-      We have sent a password reset link to the email address of the account that you sepcified.
+      We have sent a password reset link to the email address of the account that you specified.
       Please check your email for this message, then click on the link.
     </p>
     <div ng-show="requestFailed" class="alert alert-danger">

--- a/src/stormpath.auth.js
+++ b/src/stormpath.auth.js
@@ -3,18 +3,19 @@
  * @ngdoc overview
  * @name  stormpath.authService
  * @description
- * This module provides the {@link stormpath.authService.$auth $auth} service
+ * This module provides the {@link stormpath.authService.$auth $auth} service.
  *
- * Currently this provider does not have any configuration methods
+ * Currently this provider does not have any configuration methods.
  */
 /**
  * @ngdoc object
  * @name stormpath.authService.$authProvider
+ *
  * @description
  *
- * Provides the {@link stormpath.authService.$auth $auth} service
+ * Provides the {@link stormpath.authService.$auth $auth} service.
  *
- * Currently this provider does not have any configuration methods
+ * Currently this provider does not have any configuration methods.
  */
 angular.module('stormpath.auth',['stormpath.CONFIG'])
 .config(['$injector','STORMPATH_CONFIG',function $authProvider($injector,STORMPATH_CONFIG){
@@ -36,17 +37,27 @@ angular.module('stormpath.auth',['stormpath.CONFIG'])
          * @ngdoc function
          * @name  stormpath.authService.$auth#authenticate
          * @methodOf stormpath.authService.$auth
-         * @param {Object} credentialData An object literal for passing
-         * usernmae & password, or social provider token
+         *
+         * @param {Object} credentialData
+         *
+         * An object literal for passing
+         * username & password, or social provider token.
+         *
          * @description
-         * Sends the provided credential data to your backend server, the server
-         * handler should verify the credentials and return an access token which is
-         * store in an HTTP-only cookie.
-         * @returns {promise} A promise which is resolved with the authntication
+         *
+         * Sends the provided credential data to your backend server. The server
+         * handler should verify the credentials and return an access token, which is
+         * stored in an HTTP-only cookie.
+         *
+         * @returns {promise}
+         *
+         * A promise that is resolved with the authentication
          * response or error response (both are response objects from the $http
          * service).
+         *
          * @example
          * ## Username & Password example
+         *
          * <pre>
          * myApp.controller('LoginCtrl', function ($scope, $auth, $state) {
          *   $scope.errorMessage = null;
@@ -106,13 +117,18 @@ angular.module('stormpath.auth',['stormpath.CONFIG'])
          * @name stormpath.authService.$auth#$authenticated
          * @eventOf stormpath.authService.$auth
          * @eventType broadcast on root scope
+         *
          * @description
+         *
          * This event is broadcast when a call to
          * {@link stormpath.authService.$auth#methods_authenticate $auth.authenticate()}
-         * is successful
+         * is successful.
          *
          * @param {Object} event Angular event object.
-         * @param {httpResponse} httpResponse The http response from the $http service.  If
+         *
+         * @param {httpResponse} httpResponse
+         *
+         * The http response from the $http service.  If
          * you are writing your access tokens to the response body when a user
          * authenticates, you will want to use this response object to get access
          * to that token.

--- a/src/stormpath.emailverification.js
+++ b/src/stormpath.emailverification.js
@@ -52,13 +52,13 @@ angular.module('stormpath')
  *
  * Use this directive on the page that users land on when they click an email verification link.
  * These links are sent after a user registers, see
- * {@link stormpath.spRegistrationForm:spRegistrationForm spRegistrationForm}
+ * {@link stormpath.spRegistrationForm:spRegistrationForm spRegistrationForm}.
  *
  * This directive will render a view which does the following:
  * * Verifies that the current URL has an `sptoken` in it.  Shows an error if not.
  * * Verifies the given `sptoken` with Stormpath, then:
  *   * If the token is valid, tell the user that confirmation is complete and prompt the user to login.
- *   * If the token is invalid (it is expired or malformed) we prompt the user to enter
+ *   * If the token is invalid (it is expired or malformed), we prompt the user to enter
  *     their email address, so that we can try sending them a new link.
  *
  * @param {string} template-url An alternate template URL, if you want

--- a/src/stormpath.formencoder.js
+++ b/src/stormpath.formencoder.js
@@ -3,8 +3,8 @@
 angular.module('stormpath')
 .provider('$spFormEncoder', [function $spFormEncoder(){
   /**
-   * This service is intenally exclude from NG Docs
-   * It is an internal utility
+   * This service is intentionally excluded from NG Docs.
+   * It is an internal utility.
    */
 
   this.$get = [

--- a/src/stormpath.login.js
+++ b/src/stormpath.login.js
@@ -25,7 +25,8 @@ angular.module('stormpath')
  * @name stormpath.spLoginForm:spLoginForm
  *
  * @description
- * This directive will render a pre-built login form, with all
+ *
+ * This directive will render a pre-built login form with all
  * the necessary fields.  After the login is a success, the following
  * will happen:
  *
@@ -36,10 +37,13 @@ angular.module('stormpath')
  *  * The user is sent back to the view they originally requested
  *  * The user is sent to a default view of your choice
  *
- * @param {string} template-url An alternate template URL, if you want
+ * @param {string} template-url
+ *
+ * An alternate template URL if you want
  * to use your own template for the form.
  *
  * @example
+ *
  * <pre>
  * <!-- If you want to use the default template -->
  * <div class="container">

--- a/src/stormpath.passwordreset.js
+++ b/src/stormpath.passwordreset.js
@@ -79,14 +79,18 @@ angular.module('stormpath')
  * @name stormpath.spPasswordResetRequestForm:spPasswordResetRequestForm
  *
  * @description
- * This directive will render a pre-built form which prompts the user for thier
- * username/email.  If an account is found we will send them an email with a
+ *
+ * This directive will render a pre-built form which prompts the user for their
+ * username/email.  If an account is found, we will send them an email with a
  * password reset link.
  *
- * @param {string} template-url An alternate template URL, if you want
+ * @param {string} template-url
+ *
+ * An alternate template URL if you want
  * to use your own template for the form.
  *
  * @example
+ *
  * <pre>
  * <!-- If you want to use the default template -->
  * <div class="container">
@@ -112,6 +116,7 @@ angular.module('stormpath')
  * @name stormpath.spPasswordResetForm:spPasswordResetForm
  *
  * @description
+ *
  * Use this directive on the page that users land on when they click on a password
  * reset link.  To send users a password reset link, see
  * {@link stormpath.spPasswordResetRequestForm:spPasswordResetRequestForm spPasswordResetRequestForm}
@@ -119,14 +124,17 @@ angular.module('stormpath')
  * This directive will render a password reset form which does the following:
  * * Verifies that the current URL has an `sptoken` in it.  Shows an error if not.
  * * Verifies the given `sptoken` with Stormpath, then:
- *   * If the token is valid, show a form which allows the user to enter a new password.
- *   * If the token is invalid (it is expired or malformed) we prompt the user to enter
+ *   * If the token is valid, shows a form which allows the user to enter a new password.
+ *   * If the token is invalid (it is expired or malformed), we prompt the user to enter
  *     their email address, so that we can try sending them a new link.
  *
- * @param {string} template-url An alternate template URL, if you want
+ * @param {string} template-url
+ *
+ * An alternate template URL if you want
  * to use your own template for the form.
  *
  * @example
+ *
  * <pre>
  * <!-- If you want to use the default template -->
  * <div class="container">

--- a/src/stormpath.registration.js
+++ b/src/stormpath.registration.js
@@ -53,19 +53,22 @@ angular.module('stormpath')
  * @ngdoc directive
  * @name stormpath.spRegistrationForm:spRegistrationForm
  *
- * @param {boolean} autoLogin Default `false`, automatically authenticate the user
+ * @param {boolean} autoLogin
+ *
+ * Default `false`, automatically authenticate the user
  * after creation.  This makes a call to
- * {@link stormpath.authService.$auth#methods_authenticate $auth.authenticate} which will
+ * {@link stormpath.authService.$auth#methods_authenticate $auth.authenticate}, which will
  * trigger the event {@link stormpath.authService.$auth#events_$authenticated $authenticated}.
- * This is not
- * possible if the email verification workflow is enabled on the directory that
+ * This is not possible if the email verification workflow is enabled on the directory that
  * the account is created in.
  *
- * @param {string} postLoginState If using the `autoLogin` option, you can
- * specify the name of a UI state that the user should be redirected to after
- * they successfully register
+ * @param {string} postLoginState
+ *
+ * If using the `autoLogin` option, you can specify the name of a UI state that the user
+ * should be redirected to after they successfully have registered.
  *
  * @description
+ *
  * This directive will render a pre-built user registration form with the following
  * fields:
  *  * First Name
@@ -73,7 +76,7 @@ angular.module('stormpath')
  *  * Email
  *  * Password
  *
- * # Customizing the form
+ * # Customizing the Form
  *
  * If you would like to customize the form:
  *
@@ -91,26 +94,28 @@ angular.module('stormpath')
  *
  * # Email Verification
  *
- * If you are using the email verification workflow the default template has a message
+ * If you are using the email verification workflow, the default template has a message,
  * which will be shown to the user, telling them that they need to check their email
  * for verification.
  *
- * If you are NOT using the email verification workflow you can, optionally,
+ * If you are NOT using the email verification workflow, you can, optionally,
  * automatically login the user and redirect them to a UI state in your application.
  * See the options below.
- *
  *
  * # Server Interaction
  *
  * This directive makes a call to
  * {@link stormpath.userService.$user#methods_create $user.create()}
- * when it is ready to POST the form to the server, please see that method
+ * when it is ready to POST the form to the server. Please see that method
  * for more information.
  *
- * @param {string} template-url An alternate template URL, if you want
+ * @param {string} template-url
+ *
+ * An alternate template URL if you want
  * to use your own template for the form.
  *
  * @example
+ *
  * <pre>
  * <!-- If you want to use the default template -->
  * <div class="container">

--- a/src/stormpath.user.js
+++ b/src/stormpath.user.js
@@ -2,19 +2,21 @@
 /**
  * @ngdoc overview
  * @name stormpath.userService
+ *
  * @description
  *
- * This module provides the {@link stormpath.userService.$user $user} service
+ * This module provides the {@link stormpath.userService.$user $user} service.
  */
 
 /**
  * @ngdoc object
  * @name stormpath.userService.$userProvider
+ *
  * @description
  *
- * Provides the {@link stormpath.userService.$user $user} service
+ * Provides the {@link stormpath.userService.$user $user} service.
  *
- * Currently this provider does not have any configuration methods
+ * Currently, this provider does not have any configuration methods.
  */
 
 angular.module('stormpath.userService',['stormpath.CONFIG'])
@@ -25,8 +27,9 @@ angular.module('stormpath.userService',['stormpath.CONFIG'])
    * @name stormpath.userService.$user
    *
    * @description
+   *
    * Use this service to get the current user and do access control checks
-   * on the user
+   * on the user.
    */
 
   function User(data){
@@ -54,7 +57,10 @@ angular.module('stormpath.userService',['stormpath.CONFIG'])
          * @ngdoc function
          * @name stormpath.userService.$user#create
          * @methodOf stormpath.userService.$user
-         * @param {Object} accountData An object literal for passing the data
+         *
+         * @param {Object} accountData
+         *
+         * An object literal for passing the data
          * for the new account.
          *
          * Required fields:
@@ -64,9 +70,10 @@ angular.module('stormpath.userService',['stormpath.CONFIG'])
          * * `password` - the password that the user wishes to use for their
          * account.  Must meet the password requirements that you have specified
          * on the directory that this account will be created in.
+         *
          * @description
          *
-         * Attemps to create a new user by submitting the given `accountData` as
+         * Attempts to create a new user by submitting the given `accountData` as
          * JSON to `/api/users`.  The POST endpoint can be modified via the
          * {@link stormpath.config#USER_COLLECTION_URI USER_COLLECTION_URI} config option.
          *
@@ -75,14 +82,16 @@ angular.module('stormpath.userService',['stormpath.CONFIG'])
          *
          * If email verification is enabled, you should send a `202` response instead.
          *
-         *  If you are using our Express.JS SDK you can simply attach the
+         *  If you are using our Express.JS SDK, you can simply attach the
          *  <a href="https://github.com/stormpath/stormpath-sdk-express#register" target="_blank">`register`</a> middleware
          * to your application and these responses will be handled automatically for you.
          *
-         * @returns {promise} A promise representing the operation to create a
-         * new user.  If an error occurs (duplicate email, weak password) the
+         * @returns {promise}
+         *
+         * A promise representing the operation to create a
+         * new user.  If an error occurs (duplicate email, weak password), the
          * promise will be rejected and the http response will be passed.
-         * If the operation is successful the promise
+         * If the operation is successful, the promise
          * will be resolved with a boolean `enabled` value.
          *
          * * If `true`, the
@@ -94,6 +103,7 @@ angular.module('stormpath.userService',['stormpath.CONFIG'])
          * account.
          *
          * @example
+         *
          * <pre>
          * $user.create(accountData)
          *   .then(function(created){
@@ -126,23 +136,27 @@ angular.module('stormpath.userService',['stormpath.CONFIG'])
          * @ngdoc function
          * @name stormpath.userService.$user#get
          * @methodOf stormpath.userService.$user
+         *
          * @description
          *
          * Attempt to get the current user.  Returns a promise.  If the user
-         * is authenticated the promise will be resolved with the user object.
-         * If the user is not authenticated the promise will be rejected and
+         * is authenticated, the promise will be resolved with the user object.
+         * If the user is not authenticated, the promise will be rejected and
          * passed the error response from the $http service.
          *
-         * If you cannot make use of the promise you can also obseve the
+         * If you cannot make use of the promise, you can also observe the
          * {@link $notLoggedin $notLoggedin} or {@link $currentUser $currentUser}
          * events.  They are emitted when this method has a success or failure.
          *
          * The user object is a Stormpath Account
-         * object which is wrapped by by a {@link eh User} type
+         * object, which is wrapped by a {@link eh User} type.
          *
-         * @returns {promise} A promise representing the operation to get the current user data
+         * @returns {promise}
+         *
+         * A promise representing the operation to get the current user data
          *
          * @example
+         *
          * <pre>
          * var myApp = angular.module('myApp', ['stormmpath']);
          *
@@ -224,12 +238,14 @@ angular.module('stormpath.userService',['stormpath.CONFIG'])
          * @name stormpath.userService.$user#$currentUser
          * @eventOf stormpath.userService.$user
          * @eventType broadcast on root scope
+         *
          * @description
+         *
          * This event is broadcast when a call to
          * {@link stormpath.userService.$user#methods_get $user.get()}
-         * results in a {@link User User} object
+         * results in a {@link User User} object.
          *
-         * See the next section, the $notLoggeInEvent, for example usage
+         * See the next section, the $notLoggeInEvent, for example usage.
          *
          * @param {Object} event Angular event object.
          * @param {User} user The current user object
@@ -243,21 +259,24 @@ angular.module('stormpath.userService',['stormpath.CONFIG'])
          * @name stormpath.userService.$user#$notLoggedIn
          * @eventOf stormpath.userService.$user
          * @eventType broadcast on root scope
+         *
          * @description
+         *
          * This event is broadcast when a call to
          * {@link stormpath.userService.$user#methods_get $user.get()}
-         * results in an authentication failure
+         * results in an authentication failure.
          *
          * This event is useful for situations where you want to trigger
          * the call to get the current user, but need to respond to it
-         * from some other place in your application.  An example could be
-         * during application bootstrap: you make a single call to get the current
+         * from some other place in your application.  An example could be,
+         * during application bootstrap, you make a single call to get the current
          * user from the run function, then react to it inside your
          * application controller.
          *
          * @param {Object} event Angular event object.
          *
          * @example
+         *
          * <pre>
          * var myApp = angular.module('myApp', ['stormmpath']);
          * myApp.run(function($user){
@@ -267,6 +286,7 @@ angular.module('stormpath.userService',['stormpath.CONFIG'])
          *   //
          *   $user.get();
          * });
+         *
          * myApp.controller('MyAppCtrl', function ($scope, $rootScope) {
          *   $scope.isVisible = false; // Wait for authentication
          *   $rootScope.$on('$notLoggedIn',function(){


### PR DESCRIPTION
I've edited all the documentation in the repository. I've made the punctuation and spacing more consistent and I've corrected the spelling mistakes. There also was a semicolon that was missing from the example code, but I've fixed that. 

I haven't changed the spacing between sentences because it seems like you prefer two spaces after each sentence. Therefore, I've gone through the documentation and made two spaces after each sentence. I think there were only one or two instances where two spaces did not occur. 

Other changes that I have made were in the descriptions of the directives/services. Sometimes the descriptions were smashed together, making it difficult to read. Thus, when necessary, I separated the titles of each description/service by one space (top and bottom) so that it is easier to read as a whole. One more thing I have noticed, but did not change, is the @description in each JS file is sometimes at the beginning of the documentation and sometimes at the end. I wasn't sure if that is intentional, so I kept it as is. Perhaps you could tell me if you would like it to be always at the top of the documentation, instead of at the bottom, and I can change it. 
