### PR TITLE
CORS Support for cookies

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -84,6 +84,20 @@
  * </pre>
  */
 angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userService'])
+.factory('SpAuthInterceptor',[function(){
+  function SpAuthInterceptor(){
+
+  }
+  SpAuthInterceptor.prototype.request = function(config){
+    config.withCredentials=true;
+    return config;
+  };
+
+  return new SpAuthInterceptor();
+}])
+.config(['$httpProvider',function($httpProvider){
+  $httpProvider.interceptors.push('SpAuthInterceptor');
+}])
 .provider('$stormpath', [function $stormpathProvider(){
   /**
    * @ngdoc object

--- a/src/stormpath.auth.js
+++ b/src/stormpath.auth.js
@@ -89,7 +89,7 @@ angular.module('stormpath.auth',['stormpath.CONFIG'])
          * </pre>
          */
         var op = $http($spFormEncoder.formPost({
-            url: STORMPATH_CONFIG.AUTHENTICATION_ENDPOINT,
+            url: STORMPATH_CONFIG.getUrl('AUTHENTICATION_ENDPOINT'),
             method: 'POST',
             withCredentials: true,
             data: data,
@@ -105,7 +105,7 @@ angular.module('stormpath.auth',['stormpath.CONFIG'])
       };
 
       AuthService.prototype.endSession = function endSession(){
-        var op = $http.get(STORMPATH_CONFIG.DESTROY_SESSION_ENDPOINT);
+        var op = $http.get(STORMPATH_CONFIG.getUrl('DESTROY_SESSION_ENDPOINT'));
         op.then(function(){
           $rootScope.$broadcast(STORMPATH_CONFIG.SESSION_END_EVENT);
         },function(response){

--- a/src/stormpath.config.js
+++ b/src/stormpath.config.js
@@ -1,24 +1,31 @@
 'use strict';
 
 angular.module('stormpath.CONFIG',[])
-.constant('STORMPATH_CONFIG',{
-  AUTHENTICATION_ENDPOINT: '/oauth/token',
-  CURRENT_USER_URI: '/api/users/current',
-  USER_COLLECTION_URI: '/api/users',
-  DESTROY_SESSION_ENDPOINT: '/logout',
-  RESEND_EMAIL_VERIFICATION_ENDPOINT: '/api/verificationEmails',
-  EMAIL_VERIFICATION_ENDPOINT: '/api/emailVerificationTokens',
-  PASSWORD_RESET_TOKEN_COLLECTION_ENDPOINT: '/api/passwordResetTokens',
-  GET_USER_EVENT: '$currentUser',
-  SESSION_END_EVENT: '$sessionEnd',
-  UNAUTHORIZED_EVENT: 'unauthorized',
-  LOGIN_STATE_NAME: 'login',
-  FORBIDDEN_STATE_NAME: 'forbidden',
-  AUTHENTICATION_SUCCESS_EVENT_NAME: '$authenticated',
-  AUTHENTICATION_FAILURE_EVENT_NAME: '$authenticationFailure',
-  AUTH_SERVICE_NAME: '$auth',
-  NOT_LOGGED_IN_EVENT: '$notLoggedin',
-  STATE_CHANGE_UNAUTHENTICATED: '$stateChangeUnauthenticated',
-  STATE_CHANGE_UNAUTHORIZED: '$stateChangeUnauthorized',
-  FORM_CONTENT_TYPE: ''
-});
+.constant('STORMPATH_CONFIG',(function stormpathConfigBuilder(){
+  var c={
+    ENDPOINT_PREFIX: '',
+    AUTHENTICATION_ENDPOINT: '/oauth/token',
+    CURRENT_USER_URI: '/api/users/current',
+    USER_COLLECTION_URI: '/api/users',
+    DESTROY_SESSION_ENDPOINT: '/logout',
+    RESEND_EMAIL_VERIFICATION_ENDPOINT: '/api/verificationEmails',
+    EMAIL_VERIFICATION_ENDPOINT: '/api/emailVerificationTokens',
+    PASSWORD_RESET_TOKEN_COLLECTION_ENDPOINT: '/api/passwordResetTokens',
+    GET_USER_EVENT: '$currentUser',
+    SESSION_END_EVENT: '$sessionEnd',
+    UNAUTHORIZED_EVENT: 'unauthorized',
+    LOGIN_STATE_NAME: 'login',
+    FORBIDDEN_STATE_NAME: 'forbidden',
+    AUTHENTICATION_SUCCESS_EVENT_NAME: '$authenticated',
+    AUTHENTICATION_FAILURE_EVENT_NAME: '$authenticationFailure',
+    AUTH_SERVICE_NAME: '$auth',
+    NOT_LOGGED_IN_EVENT: '$notLoggedin',
+    STATE_CHANGE_UNAUTHENTICATED: '$stateChangeUnauthenticated',
+    STATE_CHANGE_UNAUTHORIZED: '$stateChangeUnauthorized',
+    FORM_CONTENT_TYPE: ''
+  };
+  c.getUrl = function(key) {
+    return this.ENDPOINT_PREFIX + this[key];
+  };
+  return c;
+})());

--- a/src/stormpath.login.js
+++ b/src/stormpath.login.js
@@ -14,7 +14,7 @@ angular.module('stormpath')
     $auth.authenticate($scope.formModel)
       .catch(function(response){
         $scope.posting = false;
-        $scope.error = response.data.errorMessage;
+        $scope.error = response.data && response.data.errorMessage || 'XHR Error';
       });
   };
 }])

--- a/src/stormpath.user.js
+++ b/src/stormpath.user.js
@@ -151,7 +151,7 @@ angular.module('stormpath.userService',['stormpath.CONFIG'])
         var op = $q.defer();
 
         $http($spFormEncoder.formPost({
-            url: STORMPATH_CONFIG.USER_COLLECTION_URI,
+            url: STORMPATH_CONFIG.getUrl('USER_COLLECTION_URI'),
             method: 'POST',
             data: accountData
           }))
@@ -215,7 +215,7 @@ angular.module('stormpath.userService',['stormpath.CONFIG'])
         }else{
           self.cachedUserOp = op;
 
-          $http.get(STORMPATH_CONFIG.CURRENT_USER_URI).then(function(response){
+          $http.get(STORMPATH_CONFIG.getUrl('CURRENT_USER_URI')).then(function(response){
             self.cachedUserOp = null;
             self.currentUser = new User(response.data);
             currentUserEvent(self.currentUser);
@@ -235,31 +235,31 @@ angular.module('stormpath.userService',['stormpath.CONFIG'])
       UserService.prototype.resendVerificationEmail = function resendVerificationEmail(data){
         return $http($spFormEncoder.formPost({
           method: 'POST',
-          url: STORMPATH_CONFIG.RESEND_EMAIL_VERIFICATION_ENDPOINT,
+          url: STORMPATH_CONFIG.getUrl('RESEND_EMAIL_VERIFICATION_ENDPOINT'),
           data: data
         }));
       };
       UserService.prototype.verify = function verify(data){
         return $http($spFormEncoder.formPost({
           method: 'POST',
-          url: STORMPATH_CONFIG.EMAIL_VERIFICATION_ENDPOINT,
+          url: STORMPATH_CONFIG.getUrl('EMAIL_VERIFICATION_ENDPOINT'),
           data: data
         }));
       };
       UserService.prototype.verifyPasswordResetToken = function verifyPasswordResetToken(token){
-        return $http.get(STORMPATH_CONFIG.PASSWORD_RESET_TOKEN_COLLECTION_ENDPOINT+'/'+token);
+        return $http.get(STORMPATH_CONFIG.getUrl('PASSWORD_RESET_TOKEN_COLLECTION_ENDPOINT')+'/'+token);
       };
       UserService.prototype.passwordResetRequest = function passwordResetRequest(data){
         return $http($spFormEncoder.formPost({
           method: 'POST',
-          url: STORMPATH_CONFIG.PASSWORD_RESET_TOKEN_COLLECTION_ENDPOINT,
+          url: STORMPATH_CONFIG.getUrl('PASSWORD_RESET_TOKEN_COLLECTION_ENDPOINT'),
           data: data
         }));
       };
       UserService.prototype.resetPassword = function resetPassword(token,data){
         return $http($spFormEncoder.formPost({
           method: 'POST',
-          url: STORMPATH_CONFIG.PASSWORD_RESET_TOKEN_COLLECTION_ENDPOINT+'/'+token,
+          url:STORMPATH_CONFIG.getUrl('PASSWORD_RESET_TOKEN_COLLECTION_ENDPOINT')+'/'+token,
           data: data
         }));
       };

--- a/src/stormpath.user.js
+++ b/src/stormpath.user.js
@@ -215,7 +215,7 @@ angular.module('stormpath.userService',['stormpath.CONFIG'])
         }else{
           self.cachedUserOp = op;
 
-          $http.get(STORMPATH_CONFIG.getUrl('CURRENT_USER_URI')).then(function(response){
+          $http.get(STORMPATH_CONFIG.getUrl('CURRENT_USER_URI'),{withCredentials:true}).then(function(response){
             self.cachedUserOp = null;
             self.currentUser = new User(response.data);
             currentUserEvent(self.currentUser);


### PR DESCRIPTION
- Support CORS situations by using the `withCredentials` option
- Added the ENDPOINT_PREFIX config variable, allowing you to define the root of your endpoint URLs for all URLs (rather than having to re-define every URL)
