### PR TITLE
Replace jquery dependent show() and hide() calls with add/remove ng-hide

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -489,9 +489,9 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
     link: function(scope,element){
       $rootScope.$watch('user',function(user){
         if(user && user.href){
-          element.show();
+          element.removeClass('ng-hide');
         }else{
-          element.hide();
+          element.addClass('ng-hide');
         }
       });
     }
@@ -520,9 +520,9 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
     link: function(scope,element){
       $rootScope.$watch('user',function(user){
         if(user && user.href){
-          element.hide();
+          element.addClass('ng-hide');
         }else{
-          element.show();
+          element.removeClass('ng-hide');
         }
       });
     }
@@ -599,9 +599,9 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
       function evalElement(){
         var user = $user.currentUser;
         if(user && user.groupTest(expr)){
-          element.show();
+          element.removeClass('ng-hide');
         }else{
-          element.hide();
+          element.addClass('ng-hide');
         }
       }
 
@@ -651,9 +651,9 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
       function evalElement(){
         var user = $user.currentUser;
         if(user && user.groupTest(expr)){
-          element.hide();
+          element.addClass('ng-hide');
         }else{
-          element.show();
+          element.removeClass('ng-hide');
         }
       }
 
@@ -686,9 +686,9 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
     link: function(scope,element){
       $rootScope.$watch('user',function(){
         if($user.currentUser || ($user.currentUser===false)){
-          element.hide();
+          element.addClass('ng-hide');
         }else{
-          element.show();
+          element.removeClass('ng-hide');
         }
       });
     }
@@ -724,9 +724,9 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
     link: function(scope,element){
       $rootScope.$watch('user',function(){
         if($user.currentUser || ($user.currentUser===false)){
-          element.show();
+          element.removeClass('ng-hide');
         }else{
-          element.hide();
+          element.addClass('ng-hide');
         }
       });
     }
@@ -756,9 +756,9 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
     link: function(scope,element){
       $rootScope.$watch('user',function(){
         if($user.currentUser === null){
-          element.show();
+          element.removeClass('ng-hide');
         }else{
-          element.hide();
+          element.addClass('ng-hide');
         }
       });
     }


### PR DESCRIPTION
This PR replaces all the show() and hide() jQuery calls with addClass/removeClass using the ng-hide class from angular.  I believe this removes the dependency on jQuery, at least for my sample app and fixes issue #27.

I didn't have Sphinx, so I wasn't able to build the docs target.  I did remove docs locally from build, so that I could run build/dist and bower link to test inside my project.

Since this change was entirely internal I didn't see any docs or tests that needed updating.  If there are any, let me know and I'd be happy to update them.
