### PR TITLE
Add provider data support to auth service

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -489,9 +489,9 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
     link: function(scope,element){
       $rootScope.$watch('user',function(user){
         if(user && user.href){
-          element.show();
+          element.removeClass('ng-hide');
         }else{
-          element.hide();
+          element.addClass('ng-hide');
         }
       });
     }
@@ -520,9 +520,9 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
     link: function(scope,element){
       $rootScope.$watch('user',function(user){
         if(user && user.href){
-          element.hide();
+          element.addClass('ng-hide');
         }else{
-          element.show();
+          element.removeClass('ng-hide');
         }
       });
     }
@@ -599,9 +599,9 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
       function evalElement(){
         var user = $user.currentUser;
         if(user && user.groupTest(expr)){
-          element.show();
+          element.removeClass('ng-hide');
         }else{
-          element.hide();
+          element.addClass('ng-hide');
         }
       }
 
@@ -651,9 +651,9 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
       function evalElement(){
         var user = $user.currentUser;
         if(user && user.groupTest(expr)){
-          element.hide();
+          element.addClass('ng-hide');
         }else{
-          element.show();
+          element.removeClass('ng-hide');
         }
       }
 
@@ -686,9 +686,9 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
     link: function(scope,element){
       $rootScope.$watch('user',function(){
         if($user.currentUser || ($user.currentUser===false)){
-          element.hide();
+          element.addClass('ng-hide');
         }else{
-          element.show();
+          element.removeClass('ng-hide');
         }
       });
     }
@@ -724,9 +724,9 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
     link: function(scope,element){
       $rootScope.$watch('user',function(){
         if($user.currentUser || ($user.currentUser===false)){
-          element.show();
+          element.removeClass('ng-hide');
         }else{
-          element.hide();
+          element.addClass('ng-hide');
         }
       });
     }
@@ -756,9 +756,9 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
     link: function(scope,element){
       $rootScope.$watch('user',function(){
         if($user.currentUser === null){
-          element.show();
+          element.removeClass('ng-hide');
         }else{
-          element.hide();
+          element.addClass('ng-hide');
         }
       });
     }

--- a/src/stormpath.auth.js
+++ b/src/stormpath.auth.js
@@ -91,6 +91,31 @@ angular.module('stormpath.auth',['stormpath.CONFIG'])
          *
          * });
          * </pre>
+         *
+         * ## Social Login example
+         *
+         * <pre>
+         * myApp.controller('LoginCtrl', function ($scope, $auth, $state) {
+         *   $scope.errorMessage = null;
+         *   $scope.formData = {
+         *     providerId: 'facebook',         // Get access token from FB sdk login
+         *     accessToken: 'CABTmZxAZBxBADbr1l7ZCwHpjivBt9T0GZBqjQdTmgyO0OkUq37HYaBi4F23f49f5',
+         *   };
+         *
+         *   // Use this method with ng-submit on your form
+         *   $scope.login = function login(formData){
+         *     $auth.authenticate(formData)
+         *      .then(function(){
+         *        console.log('login success');
+         *        $state.go('home');
+         *      })
+         *      .catch(function(httpResponse){
+         *        $scope.errorMessage = response.data.message;
+         *      });
+         *   }
+         *
+         * });
+         * </pre>
          */
         var op = $http($spFormEncoder.formPost({
             url: STORMPATH_CONFIG.getUrl('AUTHENTICATION_ENDPOINT'),
@@ -98,7 +123,9 @@ angular.module('stormpath.auth',['stormpath.CONFIG'])
             withCredentials: true,
             data: data,
             params: {
-              'grant_type': 'password'
+              'grant_type': data.providerId
+                  ? 'social'
+                  : 'password'
             }
           })
         );


### PR DESCRIPTION
This PR adds support for sending a unique grant_type if authenticate is called with providerId and accessToken for social login.  I based this off the PR that eliminates jQuery, but I can rebase it off master if that PR isn't merged in (but please remove the dependency on jQuery!).

This closes issue #33.
