### PR TITLE
Add support for social login with Facebook, Google

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -89,8 +89,7 @@ angular.module('stormpath', [
   'stormpath.userService',
   'stormpath.socialLogin',
   'stormpath.facebookLogin',
-  'stormpath.googleLogin',
-  'stormpath.linkedinLogin'
+  'stormpath.googleLogin'
 ])
 .factory('SpAuthInterceptor',[function(){
   function SpAuthInterceptor(){

--- a/src/module.js
+++ b/src/module.js
@@ -83,7 +83,15 @@
  * });
  * </pre>
  */
-angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userService'])
+angular.module('stormpath', [
+  'stormpath.CONFIG',
+  'stormpath.auth',
+  'stormpath.userService',
+  'stormpath.socialLogin',
+  'stormpath.facebookLogin',
+  'stormpath.googleLogin',
+  'stormpath.linkedinLogin'
+])
 .factory('SpAuthInterceptor',[function(){
   function SpAuthInterceptor(){
 

--- a/src/spLoginForm.tpl.html
+++ b/src/spLoginForm.tpl.html
@@ -18,6 +18,11 @@
         <div class="col-sm-offset-4 col-sm-4">
           <p class="text-danger" ng-show="error" ng-bind="error"></p>
           <button type="submit" class="btn btn-primary" ng-disabled="posting">Login</button>
+
+          <div ng-repeat="(name, provider) in socialLoginProviders">
+            <button ng-show="provider.enabled" type="button" class="btn btn-primary" sp-social-login="{{name}}">Login with {{provider.service.name}}</button>
+          </div>
+
           <a href="/forgot" class="pull-right">Forgot Password</a>
         </div>
       </div>

--- a/src/spLoginForm.tpl.html
+++ b/src/spLoginForm.tpl.html
@@ -1,7 +1,37 @@
+<style>
+  .btn.btn-social {
+    margin-right: 7px;
+    min-width: 100px;
+  }
+
+  .btn.btn-facebook {
+    color: white;
+    background-color: #3B5998;
+    border-color: #37528C;
+  }
+  .btn.btn-facebook:hover,
+  .btn.btn-facebook:focus {
+    color: white;
+    background-color: #2F487B;
+    border-color: #2F487B;
+  }
+
+  .btn.btn-google {
+    color: white;
+    background-color: #dc4e41;
+    border-color: #C1453A;
+  }
+  .btn.btn-google:hover,
+  .btn.btn-google:focus {
+    color: white;
+    background-color: #C74539;
+    border-color: #AF4138;
+  }
+</style>
+
 <div class="row">
   <div class="col-xs-12">
     <form class="form-horizontal" ng-hide="accepted" ng-submit="submit()">
-
       <div class="form-group">
         <label for="spEmail" class="col-xs-12 col-sm-4 control-label">Email</label>
         <div class="col-xs-12 col-sm-4">
@@ -18,12 +48,15 @@
         <div class="col-sm-offset-4 col-sm-4">
           <p class="text-danger" ng-show="error" ng-bind="error"></p>
           <button type="submit" class="btn btn-primary" ng-disabled="posting">Login</button>
-
-          <div ng-repeat="(name, provider) in socialLoginProviders">
-            <button ng-show="provider.enabled" type="button" class="btn btn-primary" sp-social-login="{{name}}">Login with {{provider.service.name}}</button>
-          </div>
-
           <a href="/forgot" class="pull-right">Forgot Password</a>
+        </div>
+      </div>
+      <div class="form-group" ng-show="socialLoginProviders">
+        <div class="col-sm-offset-4 col-sm-4">
+          <p>Or login with:</p>
+          <button ng-repeat="provider in socialLoginProviders" type="button" class="btn btn-social btn-{{provider.name}}" sp-social-login="{{provider.name}}">
+            {{provider.service.name}}
+          </button>
         </div>
       </div>
     </form>

--- a/src/spRegistrationForm.tpl.html
+++ b/src/spRegistrationForm.tpl.html
@@ -1,3 +1,34 @@
+<style>
+  .btn.btn-social {
+    margin-right: 7px;
+    min-width: 100px;
+  }
+
+  .btn.btn-facebook {
+    color: white;
+    background-color: #3B5998;
+    border-color: #37528C;
+  }
+  .btn.btn-facebook:hover,
+  .btn.btn-facebook:focus {
+    color: white;
+    background-color: #2F487B;
+    border-color: #2F487B;
+  }
+
+  .btn.btn-google {
+    color: white;
+    background-color: #dc4e41;
+    border-color: #C1453A;
+  }
+  .btn.btn-google:hover,
+  .btn.btn-google:focus {
+    color: white;
+    background-color: #C74539;
+    border-color: #AF4138;
+  }
+</style>
+
 <div class="row">
   <div class="col-sm-offset-4 col-xs-12 col-sm-4">
     <p class="alert alert-success" ng-show="created && !enabled">Your account has been created.  Please check your email for a verification link.</p>
@@ -38,6 +69,14 @@
         <div class="col-sm-offset-4 col-sm-4">
           <p class="alert alert-danger" ng-show="error" ng-bind="error"></p>
           <button type="submit" class="btn btn-primary" ng-disabled="creating">Register</button>
+        </div>
+      </div>
+      <div class="form-group" ng-show="socialLoginProviders">
+        <div class="col-sm-offset-4 col-sm-4">
+          <p>Or register with:</p>
+          <button ng-repeat="provider in socialLoginProviders" type="button" class="btn btn-social btn-{{provider.name}}" sp-social-login="{{provider.name}}">
+            {{provider.service.name}}
+          </button>
         </div>
       </div>
     </form>

--- a/src/stormpath.auth.js
+++ b/src/stormpath.auth.js
@@ -131,13 +131,18 @@ angular.module('stormpath.auth',['stormpath.CONFIG'])
       };
 
       AuthService.prototype.endSession = function endSession(){
-        var op = $http.get(STORMPATH_CONFIG.getUrl('DESTROY_SESSION_ENDPOINT'));
+        var op = $http.get(STORMPATH_CONFIG.getUrl('DESTROY_SESSION_ENDPOINT'), {
+            headers: {
+                'Accept': 'application/json'
+            }
+        });
+
         op.then(function(){
           $rootScope.$broadcast(STORMPATH_CONFIG.SESSION_END_EVENT);
         },function(response){
-          $rootScope.$broadcast(STORMPATH_CONFIG.SESSION_END_EVENT);
           console.error('logout error',response);
         });
+
         return op;
       };
 

--- a/src/stormpath.auth.js
+++ b/src/stormpath.auth.js
@@ -135,6 +135,7 @@ angular.module('stormpath.auth',['stormpath.CONFIG'])
         op.then(function(){
           $rootScope.$broadcast(STORMPATH_CONFIG.SESSION_END_EVENT);
         },function(response){
+          $rootScope.$broadcast(STORMPATH_CONFIG.SESSION_END_EVENT);
           console.error('logout error',response);
         });
         return op;

--- a/src/stormpath.config.js
+++ b/src/stormpath.config.js
@@ -78,6 +78,23 @@ angular.module('stormpath.CONFIG',[])
     /**
     * @ngdoc property
     *
+    * @name SOCIAL_LOGIN_SERVICE_NAME
+    *
+    * @propertyOf stormpath.STORMPATH_CONFIG:STORMPATH_CONFIG
+    *
+    * @description
+    *
+    * Default: `$socialLogin`
+    *
+    * The name of the social login service, this changes the
+    * service name that you inject.
+    */
+    SOCIAL_LOGIN_SERVICE_NAME: '$socialLogin',
+
+
+    /**
+    * @ngdoc property
+    *
     * @name AUTHENTICATION_ENDPOINT
     *
     * @propertyOf stormpath.STORMPATH_CONFIG:STORMPATH_CONFIG
@@ -164,6 +181,24 @@ angular.module('stormpath.CONFIG',[])
     *
     */
     EMAIL_VERIFICATION_ENDPOINT: '/verify',
+
+
+    /**
+    * @ngdoc property
+    *
+    * @name OAUTH_PROVIDERS_ENDPOINT
+    *
+    * @propertyOf stormpath.STORMPATH_CONFIG:STORMPATH_CONFIG
+    *
+    * @description
+    *
+    * Default: `/oauth/provider`
+    *
+    * The endpoint that is used for fetching a list of available OAuth providers.
+    * Used by {@link stormpath.socialLoginService.$socialLogin#getProviders $socialLogin.getProviders()}.
+    *
+    */
+    OAUTH_PROVIDERS_ENDPOINT: '/oauth/providers',
 
 
     /**

--- a/src/stormpath.config.js
+++ b/src/stormpath.config.js
@@ -192,13 +192,12 @@ angular.module('stormpath.CONFIG',[])
     *
     * @description
     *
-    * Default: `/oauth/provider`
+    * Default: `/spa-config/social-providers`
     *
-    * The endpoint that is used for fetching a list of available OAuth providers.
+    * The endpoint that is used for fetching a list of available social providers.
     * Used by {@link stormpath.socialLoginService.$socialLogin#getProviders $socialLogin.getProviders()}.
-    *
     */
-    OAUTH_PROVIDERS_ENDPOINT: '/oauth/providers',
+    SOCIAL_PROVIDERS_ENDPOINT: '/spa-config/social-providers',
 
 
     /**

--- a/src/stormpath.config.js
+++ b/src/stormpath.config.js
@@ -186,18 +186,20 @@ angular.module('stormpath.CONFIG',[])
     /**
     * @ngdoc property
     *
-    * @name OAUTH_PROVIDERS_ENDPOINT
+    * @name SPA_CONFIG_ENDPOINT
     *
     * @propertyOf stormpath.STORMPATH_CONFIG:STORMPATH_CONFIG
     *
     * @description
     *
-    * Default: `/spa-config/social-providers`
+    * Default: `/spa-config`
     *
-    * The endpoint that is used for fetching a list of available social providers.
+    * The endpoint that is used to fetch the configuration for this app,
+    * for example a list of available social providers.
+    *
     * Used by {@link stormpath.socialLoginService.$socialLogin#getProviders $socialLogin.getProviders()}.
     */
-    SOCIAL_PROVIDERS_ENDPOINT: '/spa-config/social-providers',
+    SPA_CONFIG_ENDPOINT: '/spa-config',
 
 
     /**

--- a/src/stormpath.login.js
+++ b/src/stormpath.login.js
@@ -2,7 +2,14 @@
 
 angular.module('stormpath')
 
-.controller('SpLoginFormCtrl', ['$scope','$auth',function ($scope,$auth) {
+.controller('SpLoginFormCtrl', ['$scope','$auth','$socialLogin',function ($scope,$auth,$socialLogin) {
+  // Load list of social login providers from server.
+  $socialLogin.getProviders().then(function(providers) {
+    $scope.socialLoginProviders = providers;
+  }).catch(function(err) {
+    throw new Error('Could not load social providers from back-end: ' + err.message);
+  });
+
   $scope.formModel = {
     username: '',
     password: ''
@@ -14,7 +21,7 @@ angular.module('stormpath')
     $auth.authenticate($scope.formModel)
       .catch(function(response){
         $scope.posting = false;
-        $scope.error = response.data && response.data.error || 'XHR Error';
+        $scope.error = response.data && response.data.error || 'An error occured when communicating with server.';
       });
   };
 }])

--- a/src/stormpath.login.js
+++ b/src/stormpath.login.js
@@ -5,7 +5,17 @@ angular.module('stormpath')
 .controller('SpLoginFormCtrl', ['$scope','$auth','$socialLogin',function ($scope,$auth,$socialLogin) {
   // Load list of social login providers from server.
   $socialLogin.getProviders().then(function(providers) {
-    $scope.socialLoginProviders = providers;
+    // Convert into an array.
+    $scope.socialLoginProviders = Object.keys(providers).map(function(providerName) {
+      var provider = providers[providerName];
+      provider.name = providerName;
+      return provider;
+    });
+
+    // Filter out the enabled providers.
+    $scope.socialLoginProviders = $scope.socialLoginProviders.filter(function(provider) {
+      return provider.enabled;
+    });
   }).catch(function(err) {
     throw new Error('Could not load social providers from back-end: ' + err.message);
   });

--- a/src/stormpath.registration.js
+++ b/src/stormpath.registration.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('stormpath')
-.controller('SpRegistrationFormCtrl', ['$scope','$user','$auth','$location',function ($scope,$user,$auth,$location) {
+.controller('SpRegistrationFormCtrl', ['$scope','$user','$auth','$location','$socialLogin',function ($scope,$user,$auth,$location,$socialLogin) {
   $scope.formModel = (typeof $scope.formModel==='object') ? $scope.formModel : {
     givenName:'',
     surname: '',
@@ -12,6 +12,24 @@ angular.module('stormpath')
   $scope.enabled = false;
   $scope.creating = false;
   $scope.authenticating = false;
+
+  // Load list of social login providers from server.
+  $socialLogin.getProviders().then(function(providers) {
+    // Convert into an array.
+    $scope.socialLoginProviders = Object.keys(providers).map(function(providerName) {
+      var provider = providers[providerName];
+      provider.name = providerName;
+      return provider;
+    });
+
+    // Filter out the enabled providers.
+    $scope.socialLoginProviders = $scope.socialLoginProviders.filter(function(provider) {
+      return provider.enabled;
+    });
+  }).catch(function(err) {
+    throw new Error('Could not load social providers from back-end: ' + err.message);
+  });
+
   $scope.submit = function(){
     $scope.creating = true;
     $scope.error = null;

--- a/src/stormpath.social-login.facebook.js
+++ b/src/stormpath.social-login.facebook.js
@@ -1,0 +1,67 @@
+(function() {
+  'use strict';
+
+  function loginCallback(deferred, response) {
+    var data;
+
+    switch (response.status) {
+      case 'connected':
+        deferred.resolve({
+          providerData: {
+            providerId: 'facebook',
+            accessToken: response.authResponse.accessToken
+          }
+        });
+        break;
+
+      case 'not_authorized':
+        deferred.reject(new Error('Please log into this app'));
+        break;
+
+      default:
+        deferred.reject(new Error('Please log into Facebook.'));
+    }
+  }
+
+  function FacebookLoginService($q, $spJsLoader) {
+    this.name = 'Facebook';
+    this.clientId = null;
+    this.$q = $q;
+    this.$spJsLoader = $spJsLoader;
+  }
+
+  FacebookLoginService.prototype.init = function init() {
+    var clientId = this.clientId;
+
+    window.fbAsyncInit = function() {
+      FB.init({
+        appId: clientId,
+        status: true,
+        cookie: true,
+        xfbml: true,
+        version: 'v2.4'
+      });
+    };
+
+    if (window.FB) {
+      window.fbAsyncInit();
+    } else {
+      this.$spJsLoader.load('facebook-jssdk', '//connect.facebook.net/en_US/sdk.js');
+    }
+  };
+
+  FacebookLoginService.prototype.login = function login(options) {
+    var deferred = this.$q.defer();
+
+    FB.login(loginCallback.bind(null, deferred), options);
+
+    return deferred.promise;
+  };
+
+  angular.module('stormpath.facebookLogin', [])
+  .provider('$facebookLogin', function() {
+    this.$get = ['$q', '$spJsLoader', function facebookLoginFactory($q, $spJsLoader) {
+      return new FacebookLoginService($q, $spJsLoader);
+    }];
+  });
+}());

--- a/src/stormpath.social-login.google.js
+++ b/src/stormpath.social-login.google.js
@@ -1,0 +1,58 @@
+(function() {
+  'use strict';
+
+  function GoogleLoginService($q, $spJsLoader) {
+    this.name = 'Google';
+    this.clientId = null;
+    this.googleAuth = null;
+    this.$q = $q;
+    this.$spJsLoader = $spJsLoader;
+  }
+
+  GoogleLoginService.prototype.setGoogleAuth = function setGoogleAuth(auth) {
+    this.googleAuth = auth;
+  };
+
+  GoogleLoginService.prototype.init = function init(element) {
+    var clientId = this.clientId;
+    var setGoogleAuth = this.setGoogleAuth.bind(this);
+
+    this.$spJsLoader.load('google-jssdk', '//apis.google.com/js/api:client.js').then(function() {
+      gapi.load('auth2', function() {
+        var auth2 = gapi.auth2.init({
+          client_id: clientId,
+          cookiepolicy: 'single_host_origin'
+        });
+
+        setGoogleAuth(auth2);
+      });
+    });
+  };
+
+  GoogleLoginService.prototype.login = function login(options) {
+    var deferred = this.$q.defer();
+
+    options = options || {};
+    options.redirect_uri = 'postmessage';
+
+    this.googleAuth.grantOfflineAccess(options).then(function(response) {
+      deferred.resolve({
+        providerData: {
+          providerId: 'google',
+          code: response.code
+        }
+      });
+    }, function(err) {
+      deferred.reject(err);
+    });
+
+    return deferred.promise;
+  };
+
+  angular.module('stormpath.googleLogin', [])
+  .provider('$googleLogin', function() {
+    this.$get = ['$q', '$spJsLoader', function googleLoginFactory($q, $spJsLoader) {
+      return new GoogleLoginService($q, $spJsLoader);
+    }];
+  });
+}());

--- a/src/stormpath.social-login.js
+++ b/src/stormpath.social-login.js
@@ -30,6 +30,8 @@
       try {
         service = $injector.get('$' + providerName + 'Login');
       } catch (err) {
+        // Delete the provider from the list if we don't support it yet.
+        delete providers[providerName];
         return;
       }
 
@@ -145,7 +147,7 @@
    *
    * @description
    *
-   * Add this directive to a button or link in order to authenticate using an OAuth provider. The value should be an OAuth provider id such as google, github, facebook or linkedin.
+   * Add this directive to a button or link in order to authenticate using an OAuth provider. The value should be an OAuth provider id such as google or facebook.
    *
    * @example
    *

--- a/src/stormpath.social-login.js
+++ b/src/stormpath.social-login.js
@@ -172,7 +172,7 @@
           }
         });
 
-        element.click(function() {
+        element.bind('click', function() {
           var options = { scope: attrs.spScope }; // `scope` is OAuth scope, and not Angular scope
 
           parentScope.posting = true;

--- a/src/stormpath.social-login.js
+++ b/src/stormpath.social-login.js
@@ -49,11 +49,11 @@
    *
    * @returns {promise}
    *
-   * A promise that is resolved with the list of all available OAuth providers.
+   * A promise that is resolved with the list of all available social providers.
    *
    * @description
    *
-   * Returns a list of all OAuth providers, provided by the `/oauth/providers` endpoint.
+   * Returns a list of all social providers, provided by the `/spa-config/social-providers` endpoint.
    */
   SocialLoginService.prototype.getProviders = function getProviders() {
     var providersPromise = this.providersPromise;
@@ -66,8 +66,12 @@
     providersPromise = this.$q.defer();
     this.providersPromise = providersPromise;
 
-    this.$http.get(this.STORMPATH_CONFIG.getUrl('OAUTH_PROVIDERS_ENDPOINT')).then(function(response) {
+    this.$http.get(this.STORMPATH_CONFIG.getUrl('SOCIAL_PROVIDERS_ENDPOINT')).then(function(response) {
       var providers = response.data;
+
+      if (!providers || typeof providers !== 'object') {
+        providers = {};
+      }
 
       initProviders(providers);
 
@@ -147,7 +151,14 @@
    *
    * @description
    *
-   * Add this directive to a button or link in order to authenticate using an OAuth provider. The value should be an OAuth provider id such as google or facebook.
+   * Add this directive to a button or link in order to authenticate using a social provider.
+   * The value should be a social provider ID such as `google` or `facebook`.
+   *
+   * **Note:** If you are using Google+ Sign-In for server-side apps, Google recommends that you
+   * leave the Authorized redirect URI field blank in the Google Developer Console. In Stormpath,
+   * when creating the Google Directory, you must set the redirect URI to `postmessage`.
+   * 
+   * {@link http://docs.stormpath.com/guides/social-integrations/}
    *
    * @example
    *
@@ -173,7 +184,7 @@
         });
 
         element.bind('click', function() {
-          var options = { scope: attrs.spScope }; // `scope` is OAuth scope, and not Angular scope
+          var options = { scope: attrs.spScope }; // `scope` is OAuth scope, not Angular scope
 
           parentScope.posting = true;
 

--- a/src/stormpath.social-login.js
+++ b/src/stormpath.social-login.js
@@ -53,7 +53,7 @@
    *
    * @description
    *
-   * Returns a list of all social providers, provided by the `/spa-config/social-providers` endpoint.
+   * Returns a list of all social providers, provided by the `/spa-config` endpoint.
    */
   SocialLoginService.prototype.getProviders = function getProviders() {
     var providersPromise = this.providersPromise;
@@ -66,10 +66,12 @@
     providersPromise = this.$q.defer();
     this.providersPromise = providersPromise;
 
-    this.$http.get(this.STORMPATH_CONFIG.getUrl('SOCIAL_PROVIDERS_ENDPOINT')).then(function(response) {
-      var providers = response.data;
+    this.$http.get(this.STORMPATH_CONFIG.getUrl('SPA_CONFIG_ENDPOINT')).then(function(response) {
+      var providers;
 
-      if (!providers || typeof providers !== 'object') {
+      if (response.data && typeof response.data === 'object') {
+        providers = response.data.socialProviders;
+      } else {
         providers = {};
       }
 

--- a/src/stormpath.social-login.js
+++ b/src/stormpath.social-login.js
@@ -1,0 +1,195 @@
+(function() {
+  'use strict';
+
+  /**
+   * @ngdoc overview
+   *
+   * @name  stormpath.socialLoginService
+   *
+   * @description
+   *
+   * This module provides the {@link stormpath.socialLoginService.$socialLogin $socialLogin} service.
+   *
+   * Currently, this provider does not have any configuration methods.
+   */
+  function SocialLoginService(STORMPATH_CONFIG, $injector, $http, $q) {
+    this.providersPromise = null;
+    this.STORMPATH_CONFIG = STORMPATH_CONFIG;
+    this.$injector = $injector;
+    this.$http = $http;
+    this.$q = $q;
+  }
+
+  SocialLoginService.prototype.initProviders = function initProviders(providers) {
+    var $injector = this.$injector;
+
+    Object.keys(providers).forEach(function(providerName) {
+      var provider = providers[providerName];
+      var service;
+
+      try {
+        service = $injector.get('$' + providerName + 'Login');
+      } catch (err) {
+        return;
+      }
+
+      service.clientId = provider.clientId;
+      providers[providerName].service = service;
+    });
+  };
+
+  /**
+   * @ngdoc function
+   *
+   * @name  stormpath.socialLoginService.$socialLogin#getProviders
+   *
+   * @methodOf stormpath.socialLoginService.$socialLogin
+   *
+   * @returns {promise}
+   *
+   * A promise that is resolved with the list of all available OAuth providers.
+   *
+   * @description
+   *
+   * Returns a list of all OAuth providers, provided by the `/oauth/providers` endpoint.
+   */
+  SocialLoginService.prototype.getProviders = function getProviders() {
+    var providersPromise = this.providersPromise;
+    var initProviders = this.initProviders.bind(this);
+
+    if (providersPromise) {
+      return providersPromise.promise;
+    }
+
+    providersPromise = this.$q.defer();
+    this.providersPromise = providersPromise;
+
+    this.$http.get(this.STORMPATH_CONFIG.getUrl('OAUTH_PROVIDERS_ENDPOINT')).then(function(response) {
+      var providers = response.data;
+
+      initProviders(providers);
+
+      providersPromise.resolve(providers);
+    }).catch(providersPromise.reject);
+
+    return providersPromise.promise;
+  };
+
+  angular.module('stormpath.socialLogin', ['stormpath.CONFIG'])
+
+  /**
+   * @ngdoc object
+   *
+   * @name stormpath.socialLoginService.$socialLoginProvider
+   *
+   * @description
+   *
+   * Provides the {@link stormpath.socialLoginService.$socialLogin $socialLogin} service.
+   *
+   * Currently, this provider does not have any configuration methods.
+   */
+  .config(['$injector', 'STORMPATH_CONFIG', function $socialLoginProvider($injector, STORMPATH_CONFIG) {
+    /**
+     * @ngdoc object
+     *
+     * @name stormpath.socialLoginService.$socialLogin
+     *
+     * @description
+     *
+     * The social login service provides methods for letting users logging in with Facebook, Google, etc.
+     */
+    var socialLoginFactory = ['$http', '$q', '$injector', function socialLoginFactory($http, $q, $injector) {
+      return new SocialLoginService(STORMPATH_CONFIG, $injector, $http, $q);
+    }];
+
+    $injector.get('$provide').factory(STORMPATH_CONFIG.SOCIAL_LOGIN_SERVICE_NAME, socialLoginFactory);
+  }])
+
+  /**
+   * @ngdoc object
+   *
+   * @name stormpath.socialLoginService.$spJsLoader
+   *
+   * @description
+   *
+   * The `$spJsLoader` provides a method for loading scripts during runtime.
+   * Used by the social provider services to load their SDKs.
+   */
+  .factory('$spJsLoader', ['$q', function($q) {
+    return {
+      load: function load(id, src, innerHTML) {
+        var deferred = $q.defer();
+        var firstJsElement = document.getElementsByTagName('script')[0];
+        var jsElement = document.createElement('script');
+
+        if (document.getElementById(id)) {
+          deferred.resolve();
+        } else {
+          jsElement.id = id;
+          jsElement.src = src;
+          jsElement.innerHTML = innerHTML;
+          jsElement.onload = deferred.resolve;
+
+          firstJsElement.parentNode.insertBefore(jsElement, firstJsElement);
+        }
+
+        return deferred.promise;
+      }
+    };
+  }])
+
+  /**
+   * @ngdoc directive
+   *
+   * @name stormpath.spSocialLogin:spSocialLogin
+   *
+   * @description
+   *
+   * Add this directive to a button or link in order to authenticate using an OAuth provider. The value should be an OAuth provider id such as google, github, facebook or linkedin.
+   *
+   * @example
+   *
+   * <pre>
+   * <div class="container">
+   *   <button sp-social-login="facebook" sp-scope="public_profile,email">Login with Facebook</button>
+   * </div>
+   * </pre>
+   */
+  .directive('spSocialLogin', ['$socialLogin', '$auth', function($socialLogin, $auth) {
+    return {
+      link: function(scope, element, attrs) {
+        var providerService;
+        var parentScope = scope.$parent;
+
+        $socialLogin.getProviders().then(function(providers) {
+          var provider = providers[attrs.spSocialLogin];
+
+          if (provider && provider.service) {
+            providerService = provider.service;
+            providerService.init(element);
+          }
+        });
+
+        element.click(function() {
+          var options = { scope: attrs.spScope }; // `scope` is OAuth scope, and not Angular scope
+
+          parentScope.posting = true;
+
+          providerService.login(options).then(function(data) {
+            return $auth.authenticate(data);
+          }).catch(function(err) {
+            parentScope.posting = false;
+
+            if (err.message) {
+              parentScope.error = err.message;
+            } else if (err.data && err.data.error) {
+              parentScope.error = err.data.error;
+            } else {
+              parentScope.error = 'An error occured when communicating with server.';
+            }
+          });
+        });
+      }
+    };
+  }]);
+}());

--- a/src/stormpath.social-login.linkedin.js
+++ b/src/stormpath.social-login.linkedin.js
@@ -1,3 +1,7 @@
+// We've disabled support for social login with LinkedIn until we've
+// solved how to manage the differences between other OAuth providers.
+// https://developer-programs.linkedin.com/documents/exchange-jsapi-tokens-rest-api-oauth-tokens
+
 (function() {
   'use strict';
 

--- a/src/stormpath.social-login.linkedin.js
+++ b/src/stormpath.social-login.linkedin.js
@@ -1,0 +1,48 @@
+(function() {
+  'use strict';
+
+  // Returns a string in LinkedIn's format for initializing the SDK
+  // https://developer.linkedin.com/docs/signin-with-linkedin
+  function buildLinkedInSDKConfig(clientId) {
+    return 'api_key: ' + clientId + '\n' + 'authorize: true';
+  }
+
+  function loadLinkedInSDK($spJsLoader, clientId) {
+    var innerHTML = buildLinkedInSDKConfig(clientId);
+
+    $spJsLoader.load('linkedin-jssdk', '//platform.linkedin.com/in.js', innerHTML);
+  }
+
+  function LinkedInLoginService($q, $spJsLoader) {
+    this.name = 'LinkedIn';
+    this.clientId = null;
+    this.$q = $q;
+    this.$spJsLoader = $spJsLoader;
+  }
+
+  LinkedInLoginService.prototype.init = function init(element) {
+    loadLinkedInSDK(this.$spJsLoader, this.clientId);
+  };
+
+  LinkedInLoginService.prototype.login = function login(options) {
+    var deferred = this.$q.defer();
+
+    IN.User.authorize(function() {
+      deferred.resolve({
+        providerData: {
+          providerId: 'linkedin',
+          accessToken: IN.ENV.auth.oauth_token
+        }
+      });
+    });
+
+    return deferred.promise;
+  };
+
+  angular.module('stormpath.linkedinLogin', [])
+  .provider('$linkedinLogin', function() {
+    this.$get = ['$q', '$spJsLoader', function linkedInLoginFactory($q, $spJsLoader) {
+      return new LinkedInLoginService($q, $spJsLoader);
+    }];
+  });
+}());


### PR DESCRIPTION
Fixes #44.

This PR adds services and directives to facilitate the implementation of social login with Stormpath.
### Notes
- Only support for Facebook and Google initially as Github and LinkedIn has different flows
- Google Redirect URI must be set to `postmessage`
### Dependencies
- https://github.com/stormpath/express-stormpath/pull/121
### How it works
- The `SocialLogin` service asks the back-end (i.e. express-stormpath) for a list of available OAuth providers.
- It then maps them to each service, i.e. `Facebook` to the `facebookLogin` service.
- The `spLoginForm` directive will list all enabled providers.
- A click on e.g. the `Login with Facebook` button will trigger the popup.
- Once the user has authorised, they will be logged in using the `/login` route in express-stormpath.
### Includes
- `socialLogin` service that provides the `getProviders` method to get a list of OAuth providers and their Angular services
- `facebookLogin` service for login with Facebook
- `googleLogin` service for login with Google
- `spSocialLogin` directive that adds a button attached to a social provider, e.g.
  
  ``` html
  <button sp-social-login="facebook" sp-scope="public_profile,email">Login with Facebook</button>
  ```
- Edits to the login form to include social login buttons
### How to verify
1. Checkout this branch and build it using `grunt build --force`
2. Copy the files in the `dist/` folder to your own Angular app with Stormpath integrated
3. Make sure that you have an Express API up and running with the [`social-login`](https://github.com/stormpath/express-stormpath/pull/121) branch
4. Create and configure Stormpath Directories for both Facebook and Google
5. Verify that login buttons for Facebook and Google show up on the login form (`spLoginForm`)
6. Verify that it works to login with both providers, and also that the username/password flow still works
7. Verify that logout works as expected
### Screenshots

**Login:**  
<img width="586" alt="screen shot 2015-10-16 at 04 20 41" src="https://cloud.githubusercontent.com/assets/721091/10541139/91cf3bcc-73c3-11e5-9d0e-9230731362b1.png">

**Registration:**  
<img width="543" alt="screen shot 2015-10-21 at 21 14 30" src="https://cloud.githubusercontent.com/assets/721091/10647629/bb57e21c-7839-11e5-8294-97e594184267.png">
