### PR TITLE
Use group.items for group filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.7.1
+
+**Not Yet Released**
+
+Fixed the [ifUserInGroup][] and [ifUserNotInGroup][] directives to expect the
+new data format (expanded `account.groups`) from the `/me` route
+
 # 0.7.0
 
 ### ! ** Many Breaking Changes ** !

--- a/src/module.js
+++ b/src/module.js
@@ -540,6 +540,12 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
  * * A reference to a property on the $scope.  That property can be a string or
  * regular expression.
  *
+ * **Note**: This feature depends on the data that is returned by the
+ * {@link api/stormpath.STORMPATH_CONFIG:STORMPATH_CONFIG#properties_CURRENT_USER_URI CURRENT_USER_URI}.
+ * Your server should expand the account's groups before returning the user.
+ * If you are using [express-stormpath](https://github.com/stormpath/express-stormpath), simply use
+ * [Automatic Expansion](http://docs.stormpath.com/nodejs/express/latest/user_data.html#automatic-expansion)
+ *
  * # Using Regular Expressions
  *
  * If using a string expression as the attribute value, you can pass a regular
@@ -625,6 +631,12 @@ angular.module('stormpath',['stormpath.CONFIG','stormpath.auth','stormpath.userS
  *
  * This is the inverse of {@link stormpath.ifUserInGroup:ifUserInGroup ifUserInGroup},
  * please refer to that directive for full usage information.
+ *
+ * **Note**: This feature depends on the data that is returned by the
+ * {@link api/stormpath.STORMPATH_CONFIG:STORMPATH_CONFIG#properties_CURRENT_USER_URI CURRENT_USER_URI}.
+ * Your server should expand the account's groups before returning the user.
+ * If you are using [express-stormpath](https://github.com/stormpath/express-stormpath), simply use
+ * [Automatic Expansion](http://docs.stormpath.com/nodejs/express/latest/user_data.html#automatic-expansion)
  *
  * @example
  *

--- a/src/stormpath.user.js
+++ b/src/stormpath.user.js
@@ -46,7 +46,7 @@ angular.module('stormpath.userService',['stormpath.CONFIG'])
   * Please use the `ifUserInGroup` directive instead
   */
   User.prototype.inGroup = function inGroup(groupName) {
-    return this.groups.filter(function(group){
+    return this.groups.items.filter(function(group){
       return group.name === groupName;
     }).length >0;
   };
@@ -55,7 +55,7 @@ angular.module('stormpath.userService',['stormpath.CONFIG'])
   * Please use the `ifUserInGroup` directive instead
   */
   User.prototype.matchesGroupExpression = function matchesGroupExpression(regex) {
-    return this.groups.filter(function(group){
+    return this.groups.items.filter(function(group){
       return regex.test(group.name);
     }).length >0;
   };


### PR DESCRIPTION
With the old module, stormpath-sdk-express, we had a hack on the 
`/me` responder that would expand the user’s groups and attach
`group.items` directly to `user.group`

We are removing this hack

This depends on this fix: https://github.com/stormpath/express-stormpath/issues/123
