### PR TITLE
CORS Example application

### DIFF
--- a/example/cors-app/.bowerrc
+++ b/example/cors-app/.bowerrc
@@ -1,0 +1,3 @@
+{
+    "directory": "client/bower_components"
+}

--- a/example/cors-app/README.md
+++ b/example/cors-app/README.md
@@ -1,0 +1,59 @@
+# Stormpath Angular + Express + CORS
+
+This folder contains an example application that is built with the
+[Stormpath Angular SDK][] and [Stormpath Express][].
+
+This example shows you how to host your Angular application on a different
+domain from your API service.
+
+#### Running the Example Application
+
+1. To run this application, you will need Bower and Grunt as global packages:
+
+  ```bash
+  npm install -g grunt bower
+  ```
+
+2. Clone this repo to your computer, and enter the directory for this example:
+
+  ```bash
+  git clone git@github.com:stormpath/stormpath-sdk-angularjs.git
+  cd stormpath-sdk-angularjs/example/cors-app
+  ```
+
+3. Install the dependencies:
+
+  ```bash
+  npm install
+  bower install
+  ```
+4. Export your environment variables for your Stormpath Tenant and Application:
+
+  ```bash
+  export STORMPATH_CLIENT_APIKEY_ID=xxx
+  export STORMPATH_CLIENT_APIKEY_SECRET=xxx
+  export STORMPATH_APPLICATION_HREF=xxx
+  ```
+
+5. You *may* need to edit your  `/etc/hosts` file to create aliases for localhost,
+   if so you would add these lines to it:
+
+   ```
+   127.0.0.1  a.localhost
+   127.0.0.1  b.localhost
+   ```
+
+5. Start the server with the node command:
+
+  ```bash
+  node server.js
+  ```
+
+  When the Stormpath client is ready, the website http://a.localhost:3000 will
+  be opened in your Browser.  It will be communicating with your API service
+  which is running on http://b.localhost:4000
+
+
+[Stormpath Angular SDK]: https://github.com/stormpath/stormpath-sdk-angularjs
+[Stormpath Express]: https://github.com/stormpath/stormpath-express
+[Yeoman Guide]: https://docs.stormpath.com/angularjs/guide

--- a/example/cors-app/bower.json
+++ b/example/cors-app/bower.json
@@ -1,0 +1,25 @@
+{
+  "name": "cors-app",
+  "homepage": "https://github.com/stormpath/stormpath-sdk-angularjs",
+  "authors": [
+    "Robert <robert@stormpath.com>"
+  ],
+  "description": "",
+  "main": "",
+  "moduleType": [],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "app/bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "angular": "~1.4.7",
+    "stormpath-sdk-angularjs": "~0.7.1",
+    "jquery": "~2.1.4",
+    "bootstrap": "~3.3.5"
+  }
+}

--- a/example/cors-app/client/client.js
+++ b/example/cors-app/client/client.js
@@ -1,0 +1,22 @@
+'use strict';
+
+angular.module('loginApp',[
+  'stormpath',
+  'stormpath.templates'
+])
+.config(['STORMPATH_CONFIG',function (STORMPATH_CONFIG) {
+  /*
+    We tell the Stormpath library that our API service is
+    on the other domain by setting the prefix for all requests
+   */
+  STORMPATH_CONFIG.ENDPOINT_PREFIX = 'http://b.localhost:4000';
+}])
+.controller('ProtectedResourceController',['$scope','$http','$rootScope',function ($scope,$http,$rootScope) {
+  $scope.$on('$currentUser',function () {
+    $http.get('http://b.localhost:4000/api/thing')
+      .then(function (thing) {
+        $scope.thing = thing;
+      });
+  });
+}]);
+

--- a/example/cors-app/client/index.html
+++ b/example/cors-app/client/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>CORS Demo Application</title>
+  <link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.css" />
+  <script type="text/javascript" src="bower_components/jquery/dist/jquery.js"></script>
+  <script type="text/javascript" src="bower_components/angular/angular.js"></script>
+  <script type="text/javascript" src="bower_components/stormpath-sdk-angularjs/dist/stormpath-sdk-angularjs.js"></script>
+  <script type="text/javascript" src="bower_components/stormpath-sdk-angularjs/dist/stormpath-sdk-angularjs.tpls.js"></script>
+  <script type="text/javascript" src="client.js"></script>
+</head>
+<body>
+<div class="container" ng-app="loginApp">
+  <br/>
+  <div if-user ng-controller="ProtectedResourceController">
+    <p><a class="btn btn-primary" sp-logout>Logout</a></p>
+    <pre ng-bind="thing ? (thing | json) : 'Fetching thing..'"></pre>
+  </div>
+  <div if-user-state-known>
+    <div if-not-user sp-login-form></div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/example/cors-app/package.json
+++ b/example/cors-app/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "cors-app",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "cors": "^2.7.1",
+    "express": "^4.13.3",
+    "express-stormpath": "^2.0.11",
+    "open": "0.0.5"
+  }
+}

--- a/example/cors-app/server.js
+++ b/example/cors-app/server.js
@@ -1,0 +1,57 @@
+var cors = require('cors');
+var express = require('express');
+var stormpath = require('express-stormpath');
+var open = require('open');
+var path = require('path');
+
+/*
+  The websiteService is a naive Express app, it's only
+  purpose is to serve the assets for our Angular application
+ */
+
+var websiteDomain = 'http://a.localhost:3000';
+
+var websiteService = express();
+
+websiteService.use('/',express.static(path.join(__dirname,'client')));
+
+websiteService.listen(3000,function () {
+  open(websiteDomain);  // Opens the Angular app in your browser
+});
+
+/*
+  The apiService is your API that you want to protect with
+  Stormpath.  We use the CORS module to whitelist the website
+  domain, thus allowing it to communicate with the API domain
+ */
+
+var apiService = express();
+
+apiService.use(cors({
+  origin: websiteDomain,
+  credentials: true
+}));
+
+/*
+  Even though this is an API Service, we enable the
+  "website" option because this exposes the /login endpoint
+  for your Angular application to POST a login attempt to.
+ */
+
+apiService.use(stormpath.init(apiService,{
+  website: true
+}));
+
+/*
+  We use the loginRequired middleware, as that will assert
+  that the Angular client has authenticated and has valid
+  OAuth tokens in the cookies that were stpored on the API domain
+ */
+
+apiService.get('/api/thing', stormpath.loginRequired, function (req,res) {
+  res.json(req.user);
+});
+
+apiService.on('stormpath.ready',function() {
+  apiService.listen(4000);
+});


### PR DESCRIPTION
This shows you how to host your API service on a different domain than your Angular application.

The "website" option is required to enable the `/login` endpoint, which the front-end needs for posting a login attempt to.  It feels awkward to enable this option on the api service, as the api service is not a website :) I think the solution is to implement the `grant_type=password` flow for the `/oauth/token` endpoint that is served by the `express-stormpath` application.  We then:
- modify the Angular library to use the token endpoint for login
- rename the "api" option in `express-stormpath` to `oauth2`, as this option is, in-fact, enabling the OAuth features of our service.
