### PR TITLE
Closes #24

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,4 @@
 app
-dist
 docs
 example
 ngdoc_assets


### PR DESCRIPTION
Remove dist folder from the ignored file so we can use this lib with webpack or browserify.

Related to #24
