### PR TITLE
Fixes for the Yeoman app

### DIFF
--- a/example/dashboard-app/.gitignore
+++ b/example/dashboard-app/.gitignore
@@ -5,3 +5,4 @@ public
 client/bower_components
 dist
 /server/config/local.env.js
+stormpath.yml

--- a/example/dashboard-app/Gruntfile.js
+++ b/example/dashboard-app/Gruntfile.js
@@ -35,7 +35,10 @@ module.exports = function (grunt) {
     },
     express: {
       options: {
-        port: process.env.PORT || 9000
+        port: process.env.PORT || 9000,
+        // output option will force Grunt to wait for this
+        // line to be seen in server output, before continuing
+        output: 'Stormpath Ready'
       },
       dev: {
         options: {

--- a/example/dashboard-app/package.json
+++ b/example/dashboard-app/package.json
@@ -12,7 +12,7 @@
     "errorhandler": "~1.0.0",
     "express": "^4.13.3",
     "express-session": "~1.0.2",
-    "express-stormpath": "^2.1.0",
+    "express-stormpath": "^2.3.0",
     "lodash": "~2.4.1",
     "method-override": "~1.0.0",
     "morgan": "~1.0.0",

--- a/example/dashboard-app/server/app.js
+++ b/example/dashboard-app/server/app.js
@@ -24,15 +24,22 @@ var server = require('http').createServer(app);
 
 require('./config/express')(app);
 
+console.log('Initializing Stormpath');
+
 /*
   Now we initialize Stormpath, any middleware that is registered after this
   point will be protected by Stormpath.
+
+  The spaRoot setting tells the Stormpath library where your Angular app is,
+  as it will need to serve it for the default routes like /login and
+  /register.  The appPath property is provided by the configuration parser
+  in the Yeoman boilerplate.
  */
 
 app.use(ExpressStormpath.init(app,{
   website: true,
   web: {
-    spaRoot: path.join(__dirname, '..','client','index.html')
+    spaRoot: app.get('appPath')
   }
 }));
 
@@ -40,6 +47,9 @@ app.use(ExpressStormpath.init(app,{
 require('./routes')(app);
 
 app.on('stormpath.ready',function() {
+
+  console.log('Stormpath Ready');
+
   // Start server
   server.listen(config.port, config.ip, function () {
     console.log('Express server listening on %d, in %s mode', config.port, app.get('env'));

--- a/example/dashboard-app/server/config/express.js
+++ b/example/dashboard-app/server/config/express.js
@@ -21,6 +21,7 @@ module.exports = function(app) {
   app.set('views', config.root + '/server/views');
   app.engine('html', require('ejs').renderFile);
   app.set('view engine', 'html');
+  app.set('trust proxy', true);
   app.use(compression());
   app.use(bodyParser.urlencoded({ extended: true }));
   app.use(bodyParser.json());
@@ -30,7 +31,7 @@ module.exports = function(app) {
   if ('production' === env) {
     app.use(favicon(path.join(config.root, 'public', 'favicon.ico')));
     app.use(express.static(path.join(config.root, 'public')));
-    app.set('appPath', config.root + '/public');
+    app.set('appPath', path.join(config.root, 'public', 'index.html'));
     app.use(morgan('dev'));
   }
 
@@ -38,7 +39,7 @@ module.exports = function(app) {
     app.use(require('connect-livereload')());
     app.use(express.static(path.join(config.root, '.tmp')));
     app.use(express.static(path.join(config.root, 'client')));
-    app.set('appPath', 'client');
+    app.set('appPath', path.join(config.root, 'client', 'index.html'));
     app.use(morgan('dev'));
     app.use(errorHandler()); // Error handler - has to be last
   }

--- a/example/dashboard-app/server/routes.js
+++ b/example/dashboard-app/server/routes.js
@@ -19,6 +19,6 @@ module.exports = function(app) {
   // All other routes should redirect to the index.html
   app.route('/*')
     .get(function(req, res) {
-      res.sendfile(app.get('appPath') + '/index.html');
+      res.sendFile(app.get('appPath'));
     });
 };


### PR DESCRIPTION
- Fixing the `appPath` configuration builder, so that the `appPath` is correct for development environment AND production environment.  It also uses `path.join()` now
- Adding `trust proxy` option to Express, so that this application will work behind HTTPS proxies (like on Heroku)
- Upgrading the express-stormpath module
- Adding `stormpath.yml` to .gitignore, as we support this configuration file now
- Adding Grunt configuration that won’t open the application until Stormpath is ready

To test this PR:

(1) Follow the instructions in the README of the `example/dashboard-app`, to get the app running with `grunt serve`

(2) Assert that the app works and renders the SPA correctly by (a) logging into the application and (b) visiting the profile page and then (c) pressing the reload button in the browser, while looking at the profile page.  You should get the profile page again after the reload

(3) Shutdown the server then run `grunt build` to build the production distribution

(4) Then:

```
cd dist 
export NODE_ENV=production 
export STORMPATH_CLIENT_APIKEY_ID="xyz" 
export STORMPATH_CLIENT_APIKEY_SECRET="xyz" 
export STORMPATH_APPLICATION_HREF="https://api.stormpath.com/v1/applications/xyz" 
nodejs server/app.js
```

(5) Assert step (2) again, with this production build
