### PR TITLE
upgrade grunt-node-inspector

### DIFF
--- a/example/dashboard-app/package.json
+++ b/example/dashboard-app/package.json
@@ -39,7 +39,7 @@
     "grunt-svgmin": "~0.4.0",
     "grunt-usemin": "~2.1.1",
     "grunt-env": "~0.4.1",
-    "grunt-node-inspector": "~0.1.5",
+    "grunt-node-inspector": ">=0.2.0",
     "grunt-nodemon": "~0.2.0",
     "grunt-angular-templates": "^0.5.4",
     "grunt-dom-munger": "^3.4.0",


### PR DESCRIPTION
This old version of grunt-node-inspector is causing `npm install` in this example to fail, for node version 4.2.3.

On my machine, this upgrade works for node v0.12.2 and v4.2.3.  @timothyej can you verify the same?  Thanks!
