### PR TITLE
Remove the use of `bodyParser` in the example apps

### DIFF
--- a/example/dashboard-app/server/config/express.js
+++ b/example/dashboard-app/server/config/express.js
@@ -23,8 +23,6 @@ module.exports = function(app) {
   app.set('view engine', 'html');
   app.set('trust proxy', true);
   app.use(compression());
-  app.use(bodyParser.urlencoded({ extended: true }));
-  app.use(bodyParser.json());
   app.use(methodOverride());
   app.use(cookieParser());
 

--- a/example/ng-route-app/server/config/express.js
+++ b/example/ng-route-app/server/config/express.js
@@ -23,8 +23,6 @@ module.exports = function(app) {
   app.set('view engine', 'html');
   app.set('trust proxy', true);
   app.use(compression());
-  app.use(bodyParser.urlencoded({ extended: true }));
-  app.use(bodyParser.json());
   app.use(methodOverride());
   app.use(cookieParser());
 


### PR DESCRIPTION
This PR removes the use of `bodyParser` in the example apps. When following the instructions in the `README.md` of e.g. `dashboard-app`, the login request will get stuck in _pending_. This issue is being tracked here: https://github.com/stormpath/express-stormpath/issues/194
### How to verify
1. Checkout `master`
2. Go to `examples/dashboard-app`
3. Clear `node_modules/` and `client/bower_components/`
4. Run `npm cache clean`
5. Run `npm install` and `bower install`
6. Run the app with `grunt serve`
7. Try to login and verify that the login request get stuck in _pending_

Then checkout this branch and repeat the steps. Verify that the example apps (`dashboard-app` and`ng-route-app`) works as they should.
