### PR TITLE
Add support for generic handling of HTTP errors

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -208,9 +208,40 @@ angular.module('stormpath', [
 
   return new StormpathAgentInterceptor();
 }])
+/**
+ * Interceptor that intercepts Stormpath error responses and
+ * translates them to errors. Adds backward-compatibility for
+ * the error structure prior to the framework spec.
+ */
+.factory('StormpathErrorInterceptor',['$q', function($q){
+  function StormpathErrorInterceptor(){
+  }
+
+  StormpathErrorInterceptor.prototype.responseError = function(response){
+    var errorMessage = null;
+
+    if (response.data) {
+      errorMessage = response.data.message || response.data.error;
+    }
+
+    if (!errorMessage) {
+      errorMessage = 'An error occured when communicating with the API server.';
+    }
+
+    var error = new Error(errorMessage);
+    
+    error.response = response;
+    error.statusCode = response.status;
+
+    return $q.reject(error);
+  };
+
+  return new StormpathErrorInterceptor();
+}])
 .config(['$httpProvider',function($httpProvider){
   $httpProvider.interceptors.push('SpAuthInterceptor');
   $httpProvider.interceptors.push('StormpathAgentInterceptor');
+  $httpProvider.interceptors.push('StormpathErrorInterceptor');
 }])
 .provider('$stormpath', [function $stormpathProvider(){
   /**

--- a/src/stormpath.auth.js
+++ b/src/stormpath.auth.js
@@ -84,8 +84,8 @@ angular.module('stormpath.auth',['stormpath.CONFIG'])
          *        console.log('login success');
          *        $state.go('home');
          *      })
-         *      .catch(function(httpResponse){
-         *        $scope.errorMessage = response.data.message;
+         *      .catch(function(err){
+         *        $scope.errorMessage = err.message;
          *      });
          *   }
          *
@@ -109,8 +109,8 @@ angular.module('stormpath.auth',['stormpath.CONFIG'])
          *        console.log('login success');
          *        $state.go('home');
          *      })
-         *      .catch(function(httpResponse){
-         *        $scope.errorMessage = response.data.message;
+         *      .catch(function(err){
+         *        $scope.errorMessage = err.message;
          *      });
          *   }
          *

--- a/src/stormpath.login.js
+++ b/src/stormpath.login.js
@@ -31,9 +31,9 @@ angular.module('stormpath')
     $scope.posting = true;
     $scope.error = null;
     $auth.authenticate($scope.formModel)
-      .catch(function(response){
+      .catch(function(err){
         $scope.posting = false;
-        $scope.error = response.data && response.data.error || 'An error occured when communicating with server.';
+        $scope.error = err.message;
       });
   };
 }])

--- a/src/stormpath.passwordreset.js
+++ b/src/stormpath.passwordreset.js
@@ -65,8 +65,8 @@ angular.module('stormpath')
       .then(function(){
         $scope.reset = true;
       })
-      .catch(function(response){
-        $scope.error = response.data.error;
+      .catch(function(err){
+        $scope.error = err.message;
       }).finally(function(){
         $scope.posting = false;
       });

--- a/src/stormpath.registration.js
+++ b/src/stormpath.registration.js
@@ -53,8 +53,8 @@ angular.module('stormpath')
               $location.path($scope.postLoginPath);
             }
           })
-          .catch(function(response){
-            $scope.error = response.data.error;
+          .catch(function(err){
+            $scope.error = err.message;
           })
           .finally(function(){
             $scope.authenticating = false;
@@ -64,9 +64,9 @@ angular.module('stormpath')
           $scope.creating = false;
         }
       })
-      .catch(function(response){
+      .catch(function(err){
         $scope.creating = false;
-        $scope.error = response.data.error;
+        $scope.error = err.message;
       });
   };
 }])

--- a/src/stormpath.social-login.js
+++ b/src/stormpath.social-login.js
@@ -197,8 +197,6 @@
 
             if (err.message) {
               parentScope.error = err.message;
-            } else if (err.data && err.data.error) {
-              parentScope.error = err.data.error;
             } else {
               parentScope.error = 'An error occured when communicating with server.';
             }

--- a/src/stormpath.user.js
+++ b/src/stormpath.user.js
@@ -154,9 +154,9 @@ angular.module('stormpath.userService',['stormpath.CONFIG'])
          *       // The account requires email verification
          *     }
          *   })
-         *   .catch(function(response){
+         *   .catch(function(err){
          *     // Show the error message to the user
-         *     $scope.error = response.data.error;
+         *     $scope.error = err.message;
          *   });
          * </pre>
          */


### PR DESCRIPTION
Adds support for generic handling of HTTP errors. Implements the framework error spec, while maintaining backward-compatibility with non framework spec compliant backends.
##### How to verify
1. Checkout this branch.
2. Link it with Bower (`$ bower link`).
3. Build it (`$ grunt dist --force`).
4. Checkout/use one of the Stormpath AngularJS examples (that uses bower).
5. Link to our checked out branch (`$ bower link stormpath-sdk-angularjs`).
6. Start the application.
7. Navigate to the login page.
8. Login with an invalid user.
9. Validate that the error message `Invalid username or password.` is shown.
10. Open up your `package.json` file.
11. Change the dependency `express-stormpath` to `3.0.0`.
12. Run `$ npm install`.
13. Redo step 6-9.

Fixes #110.
