### PR TITLE
Prevent preflight on CORS logout request

### DIFF
--- a/src/stormpath.auth.js
+++ b/src/stormpath.auth.js
@@ -176,7 +176,8 @@ angular.module('stormpath.auth',['stormpath.CONFIG'])
       AuthService.prototype.endSession = function endSession(){
         var op = $http.post(STORMPATH_CONFIG.getUrl('DESTROY_SESSION_ENDPOINT'), null, {
             headers: {
-                'Accept': 'application/json'
+                'Accept': 'application/json',
+                'Content-Type': 'application/x-www-form-urlencoded'
             }
         });
 


### PR DESCRIPTION
This PR improves the behavior of the logout feature in CORS scenarios. Currently, Angular will send a CORS preflight (OPTIONS) request for the `/logout` POST, because this request does not qualify for a preflight skip.

See [this Stack answer](http://stackoverflow.com/a/22968724/3191599). **Tl;dr** the preflight request is caused by `Content-Type: application/json`, which is actually unnecessary for this request (since the POST is empty). Switching to `application/x-www-form-urlencoded` makes no difference to the POST, but qualifies for a preflight skip.

This cuts the number of network requests needed to logout from 2 to 1 😄  But more importantly, it removes the need for additional CORS configuration on the server. With the current behavior, the developer will need to explicitly configure their server to accept the Content-Type header.
