### PR TITLE
Remove HTTP error interceptor, use promise transform instead

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -209,40 +209,9 @@ angular.module('stormpath', [
 
   return new StormpathAgentInterceptor();
 }])
-/**
- * Interceptor that intercepts Stormpath error responses and
- * translates them to errors. Adds backward-compatibility for
- * the error structure prior to the framework spec.
- */
-.factory('StormpathErrorInterceptor',['$q', function($q){
-  function StormpathErrorInterceptor(){
-  }
-
-  StormpathErrorInterceptor.prototype.responseError = function(response){
-    var errorMessage = null;
-
-    if (response.data) {
-      errorMessage = response.data.message || response.data.error;
-    }
-
-    if (!errorMessage) {
-      errorMessage = 'An error occured when communicating with the API server.';
-    }
-
-    var error = new Error(errorMessage);
-    
-    error.response = response;
-    error.statusCode = response.status;
-
-    return $q.reject(error);
-  };
-
-  return new StormpathErrorInterceptor();
-}])
 .config(['$httpProvider',function($httpProvider){
   $httpProvider.interceptors.push('SpAuthInterceptor');
   $httpProvider.interceptors.push('StormpathAgentInterceptor');
-  $httpProvider.interceptors.push('StormpathErrorInterceptor');
 }])
 .provider('$stormpath', [function $stormpathProvider(){
   /**

--- a/src/spPasswordResetRequestForm.tpl.html
+++ b/src/spPasswordResetRequestForm.tpl.html
@@ -7,9 +7,7 @@
     <p ng-show="sent" class="pull-right">
       <a href="/login">Back to Login</a>
     </p>
-    <div ng-show="requestFailed" class="alert alert-danger">
-      Sorry, there was a problem with that email or username.  Please try again.
-    </div>
+    <div ng-show="error" class="alert alert-danger" ng-bind="error"></div>
   </div>
 </div>
 <div class="row">

--- a/src/stormpath.error-transformer.js
+++ b/src/stormpath.error-transformer.js
@@ -1,0 +1,40 @@
+'use strict';
+
+angular.module('stormpath')
+.provider('$spErrorTransformer', [function $spErrorTransformer(){
+  /**
+   * This service is intentionally excluded from NG Docs.
+   *
+   * It is an internal utility for producing error objects from $http response
+   * errors.
+   */
+
+  this.$get = [
+    function formEncoderServiceFactory(){
+
+      function ErrorTransformerService(){
+
+      }
+
+      ErrorTransformerService.prototype.transformError = function transformError(httpResponse){
+        var errorMessage = null;
+
+        if (httpResponse.data) {
+          errorMessage = httpResponse.data.message || httpResponse.data.error;
+        }
+
+        if (!errorMessage) {
+          errorMessage = 'An error occured when communicating with the server.';
+        }
+
+        var error = new Error(errorMessage);
+
+        error.httpResponse = httpResponse;
+        error.statusCode = httpResponse.status;
+        return error;
+      };
+
+      return new ErrorTransformerService();
+    }
+  ];
+}]);

--- a/src/stormpath.passwordreset.js
+++ b/src/stormpath.passwordreset.js
@@ -7,16 +7,16 @@ angular.module('stormpath')
   $scope.formModel = {
     username: ''
   };
-  $scope.requestFailed = false;
+  $scope.error = null;
   $scope.submit = function(){
     $scope.posting = true;
-    $scope.requestFailed = false;
+    $scope.error = null;
     $user.passwordResetRequest({email: $scope.formModel.email})
       .then(function(){
         $scope.sent = true;
       })
-      .catch(function(){
-        $scope.requestFailed = true;
+      .catch(function(err){
+        $scope.error = err.message;
       }).finally(function(){
         $scope.posting = false;
       });


### PR DESCRIPTION
Fixes #151 

To reproduce the problematic behavior:
1. Clone the [Stormpath Angular + Express Fullstack Sample Project](https://github.com/stormpath/express-stormpath-angular-sample-project) project
2. `npm install`
3. `node server/server.js`
4. Login, go to the profile page, delete your first name, then try to save the form.
5. Observe that you get a generic "Server Error" error, but you should be getting a specific error about givenName being required

To review this fix:
1. Clone this repo, switch to this branch
2. Run `grunt dist`
3. Copy these files into the `client/vendor` folder of the example project that you already cloned:

```
dist/stormpath-sdk-angularjs.js
dist/stormpath-sdk-angularjs.tpls.js
```
1. Repeat step 5 from the earlier reproduction situation, and you should now see the more specific error
2. Assert that all other flows (login, registration, email verification, password reset) are properly showing error messages when an error is encountered, e.g. bad password, invalid verification link.
