### PR TITLE
UI Router 1.*.* support

### DIFF
--- a/src/stormpath.oauth.js
+++ b/src/stormpath.oauth.js
@@ -65,9 +65,15 @@ function StormpathOAuthTokenProvider(STORMPATH_CONFIG) {
   * {@link stormpath.oauth.StormpathOAuthToken#setTokenStoreType StormpathOAuthToken.setTokenStoreType}.
   */
   this.$get = function $get($q, $normalizeObjectKeys, TokenStoreManager, $injector) {
-    function StormpathOAuthToken() {
-      this.tokenStore = TokenStoreManager.getTokenStore(self._tokenStoreType);
-    }
+    function StormpathOAuthToken() {}
+
+    StormpathOAuthToken.prototype.getTokenStore = function getTokenStore() {
+      if (angular.isUndefined(this.tokenStore)) {
+        this.tokenStore = TokenStoreManager.getTokenStore(self._tokenStoreType);
+      }
+
+      return this.tokenStore;
+    };
 
     /**
     * @ngdoc method
@@ -102,7 +108,7 @@ function StormpathOAuthTokenProvider(STORMPATH_CONFIG) {
       var canonicalToken = $normalizeObjectKeys(token);
       // Store a time at which we should renew the token, subtract off one second to give us some buffer of time
       canonicalToken.exp = new Date(new Date().setMilliseconds(0)+((token.expires_in-1)*1000));
-      return this.tokenStore.put(STORMPATH_CONFIG.OAUTH_TOKEN_STORAGE_NAME, canonicalToken);
+      return this.getTokenStore().put(STORMPATH_CONFIG.OAUTH_TOKEN_STORAGE_NAME, canonicalToken);
     };
 
     /**
@@ -120,7 +126,7 @@ function StormpathOAuthTokenProvider(STORMPATH_CONFIG) {
     * {@link stormpath.oauth.StormpathOAuthToken#setTokenResponse StormpathOAuthToken.setTokenResponse}.
     */
     StormpathOAuthToken.prototype.getTokenResponse = function getTokenResponse() {
-      return this.tokenStore.get(STORMPATH_CONFIG.OAUTH_TOKEN_STORAGE_NAME);
+      return this.getTokenStore().get(STORMPATH_CONFIG.OAUTH_TOKEN_STORAGE_NAME);
     };
 
     /**
@@ -136,7 +142,7 @@ function StormpathOAuthTokenProvider(STORMPATH_CONFIG) {
     * implementation details.
     */
     StormpathOAuthToken.prototype.removeToken = function removeToken() {
-      return this.tokenStore.remove(STORMPATH_CONFIG.OAUTH_TOKEN_STORAGE_NAME);
+      return this.getTokenStore().remove(STORMPATH_CONFIG.OAUTH_TOKEN_STORAGE_NAME);
     };
 
     /**

--- a/src/stormpath.ui-router.js
+++ b/src/stormpath.ui-router.js
@@ -47,7 +47,7 @@ StormpathUIRouterTransition.prototype._parseArguments = function _parseArguments
 
 /**
  * @ngdoc method
- * @name stormpath.ui-router.StormpathUIRouterTransition.isLegacy
+ * @name stormpath.ui-router.StormpathUIRouterTransition#isLegacy
  * @methodOf stormpath.ui-router.StormpathUIRouterTransition
  *
  * @returns {Boolean} Whether this is UI Router < 1.0.0
@@ -61,7 +61,7 @@ StormpathUIRouterTransition.prototype.isLegacy = function isLegacy() {
 
 /**
  * @ngdoc method
- * @name stormpath.ui-router.StormpathUIRouterTransition.sp
+ * @name stormpath.ui-router.StormpathUIRouterTransition#sp
  * @methodOf stormpath.ui-router.StormpathUIRouterTransition
  *
  * @returns {Object}
@@ -78,7 +78,7 @@ StormpathUIRouterTransition.prototype.sp = function sp() {
 
 /**
  * @ngdoc method
- * @name stormpath.ui-router.StormpathUIRouterTransition.authorities
+ * @name stormpath.ui-router.StormpathUIRouterTransition#authorities
  * @methodOf stormpath.ui-router.StormpathUIRouterTransition
  *
  * @returns {Array} List of roles authorized to enter this state
@@ -100,7 +100,7 @@ StormpathUIRouterTransition.prototype.authorities = function authorities() {
 
 /**
  * @ngdoc method
- * @name stormpath.ui-router.StormpathUIRouterTransition.fromState
+ * @name stormpath.ui-router.StormpathUIRouterTransition#fromState
  * @methodOf stormpath.ui-router.StormpathUIRouterTransition
  *
  * @returns {State} State definition for state from which the transition is occurring
@@ -116,7 +116,7 @@ StormpathUIRouterTransition.prototype.fromState = function fromState() {
 
 /**
  * @ngdoc method
- * @name stormpath.ui-router.StormpathUIRouterTransition.fromParams
+ * @name stormpath.ui-router.StormpathUIRouterTransition#fromParams
  * @methodOf stormpath.ui-router.StormpathUIRouterTransition
  *
  * @returns {Object} Parameters of the state currently being transitioned from
@@ -132,7 +132,7 @@ StormpathUIRouterTransition.prototype.fromParams = function fromParams() {
 
 /**
  * @ngdoc method
- * @name stormpath.ui-router.StormpathUIRouterTransition.toState
+ * @name stormpath.ui-router.StormpathUIRouterTransition#toState
  * @methodOf stormpath.ui-router.StormpathUIRouterTransition
  *
  * @returns {State} State definition for state to which the transition is occurring
@@ -148,7 +148,7 @@ StormpathUIRouterTransition.prototype.toState = function toState() {
 
 /**
  * @ngdoc method
- * @name stormpath.ui-router.StormpathUIRouterTransition.toParams
+ * @name stormpath.ui-router.StormpathUIRouterTransition#toParams
  * @methodOf stormpath.ui-router.StormpathUIRouterTransition
  *
  * @returns {Object} Parameters of the state currently being transitioned to
@@ -164,7 +164,7 @@ StormpathUIRouterTransition.prototype.toParams = function toParams() {
 
 /**
  * @ngdoc method
- * @name stormpath.ui-router.StormpathUIRouterTransition.pause
+ * @name stormpath.ui-router.StormpathUIRouterTransition#pause
  * @methodOf stormpath.ui-router.StormpathUIRouterTransition
  *
  * @returns {Boolean} Always `false`
@@ -187,7 +187,7 @@ StormpathUIRouterTransition.prototype.pause = function pause() {
 
 /**
  * @ngdoc method
- * @name stormpath.ui-router.StormpathUIRouterTransition.resume
+ * @name stormpath.ui-router.StormpathUIRouterTransition#resume
  * @methodOf stormpath.ui-router.StormpathUIRouterTransition
  *
  * @description
@@ -200,7 +200,7 @@ StormpathUIRouterTransition.prototype.resume = function resume() {
 
 /**
  * @ngdoc method
- * @name stormpath.ui-router.StormpathUIRouterTransition.redirect
+ * @name stormpath.ui-router.StormpathUIRouterTransition#redirect
  * @methodOf stormpath.ui-router.StormpathUIRouterTransition
  *
  * @param {State|String} state State definition or state name
@@ -214,23 +214,81 @@ StormpathUIRouterTransition.prototype.redirect = function redirect(state, params
   return this.$state.go(state.name || state, params);
 };
 
+
+/**
+ * @ngdoc service
+ * @name stormpath.ui-router.StormpathUIRouter
+ *
+ * @requires $rootScope
+ * @requires stormpath.userService.$user:$user
+ * @requires stormpath.STORMPATH_CONFIG:STORMPATH_CONFIG
+ *
+ * @description
+ * A wrapper around UI Router that allows Stormpath to connect to state transitions
+ * and perform authentication, authorization and redirection.
+ *
+ * Emits {@link stormpath.ui-router.StormpathUIRouter#$stateChangeUnauthorized $stateChangeUnauthorized}
+ * or {@link stormpath.ui-router.StormpathUIRouter#$stateChangeUnauthenticated $stateChangeUnauthenticated}
+ * in case of authorization or authentication failure, to allow for further client handling.
+ *
+ * When initialized, {@link stormpath.ui-router.StormpathUIRouter#registerUIRouterInternals StormpathUIRouter.registerUIRouterInternals()}
+ * <b>must</b> be called to inject `$state` and `$transitions` (if UIRouter >= 1.0.0) into the service.
+ */
 function StormpathUIRouter($rootScope, $user, STORMPATH_CONFIG) {
   this.$rootScope = $rootScope;
   this.$user = $user;
   this.STORMPATH_CONFIG = STORMPATH_CONFIG;
 }
 
+/**
+ * @ngdoc metod
+ * @name stormpath.ui-router.StormpathUIRouter#registerUIRouterInternals
+ * @methodOf stormpath.ui-router.StormpathUIRouter
+ *
+ * @param {TransitionsService} $transitions UIRouter 1.*.* `$transitions` service. If undefined, UIRouter 0.*.* is assumed
+ * @param {StateService} $state UIRouter `$state` service
+ * @returns {StormpathUIRouter} This instance, to allow for chaining.
+ *
+ * @description
+ * Anguiar UIRouter services are passed to this method to allow for them to be used
+ * if and only if UIRouter is the routing system being used.
+ *
+ * This method <b>must</b> be called if UIRouter is used (but the client code should not
+ * have to do so), and when called, at least `$state` must be defined.
+ */
 StormpathUIRouter.prototype.registerUIRouterInternals = function registerInternals($transitions, $state) {
   this.$transitions = $transitions;
   this.$state = $state;
   return this;
 };
 
-
+/**
+ * @ngdoc method
+ * @name stormpath.ui-router.StormpathUIRouter#isLegacy
+ * @methodOf stormpath.ui-router.StormpathUIRouter
+ *
+ * @returns {Boolean} Whether this is UI Router < 1.0.0
+ *
+ * @description
+ * Checks whether the version of UIRouter being used is 0.*.*
+ */
 StormpathUIRouter.prototype.isLegacy = function isLegacy() {
   return typeof this.$transitions === 'undefined';
 };
 
+/**
+ * @ngdoc method
+ * @name stormpath.ui-router.StormpathUIRouter#authorizeStateConfig
+ * @methodOf stormpath.ui-router.StormpathUIRouter
+ *
+ * @param {StormpathUIRouterTransition} transition Current transition
+ * @returns {Boolean} Is the user authorized to make this state transition
+ *
+ * @description
+ * Checks whether the user has the proper authorization to make the current
+ * transition to the target state. Does so by reading the state configuration's
+ * `sp.authorize` or `data.authorities` permitted role arrays.
+ */
 StormpathUIRouter.prototype.authorizeStateConfig = function authorizeStateConfig(transition) {
   var sp = transition.sp();
   var authorities = sp.authorities();
@@ -250,6 +308,38 @@ StormpathUIRouter.prototype.authorizeStateConfig = function authorizeStateConfig
   return false;
 };
 
+/**
+ * @ngdoc method
+ * @name stormpath.ui-router.StormpathUIRouter#onStateChange
+ * @methodOf stormpath.ui-router.StormpathUIRouter
+ *
+ * @param {StormpathUIRouterTransition} transition Current state transition
+ *
+ * @description
+ * Performs required checks and possibly redirects when transitioning to a state.
+ * The possible operations are:
+ *
+ * <ul>
+ *  <li>
+ *    Redirects to login state if the user is not logged in and the target state
+ *    requires authorization.
+ *  </li>
+ *  <li>
+ *    Prevents a state transition if the target state requires some role and the
+ *    user does not have this role.
+ *  </li>
+ *  <li>
+ *    Ensures that a user object will be present (either by loading it or requiring
+ *    a login) if the state is marked with `sp.waitForUser: true` .
+ *  </li>
+ *  <li>
+ *    Redirects the user back to the default post-login state if this state is
+ *    defined, and the user is trying to access the login state while authorized.
+ *  </li>
+ * </ul>
+ *
+ * If none of these conditions apply, the handler does not modify the transition.
+ */
 StormpathUIRouter.prototype.onStateChange = function onStateChange(transition) {
   var self = this;
   var sp = transition.sp();
@@ -288,7 +378,7 @@ StormpathUIRouter.prototype.onStateChange = function onStateChange(transition) {
       this.emitUnauthorized(transition);
       return transition.pause();
     }
-  }else if (transition.toState().name === this.config.loginState) {
+  } else if (transition.toState().name === this.config.loginState) {
     /*
       If the user is already logged in, we will redirect
       away from the login page and send the user to the
@@ -308,6 +398,19 @@ StormpathUIRouter.prototype.onStateChange = function onStateChange(transition) {
   }
 };
 
+/**
+ * @ngdoc method
+ * @name stormpath.ui-router.StormpathUIRouter#registerInterceptor
+ * @methodOf stormpath.ui-router.StormpathUIRouter
+ *
+ * @param {Object} config Stormpath UI router configuration
+ *
+ * @description
+ * Registers the UI Router interceptor to listen to state change events.
+ * Abstracts the operation's differences between UI Router 0.*.* and 1.*.*.
+ * The registered method is
+ * {@link stormpath.ui-router.StormpathUIRouter#onStateChange StormpathUIRouter.onStateChange()}.
+ */
 StormpathUIRouter.prototype.registerInterceptor = function registerInterceptor(config) {
   var self = this;
   this.config = config;
@@ -327,9 +430,9 @@ StormpathUIRouter.prototype.emitUnauthorized = function emitUnauthorized(transit
   /**
    * @ngdoc event
    *
-   * @name stormpath.$stormpath#$stateChangeUnauthorized
+   * @name stormpath.ui-router.StormpathUIRouter#$stateChangeUnauthorized
    *
-   * @eventOf stormpath.$stormpath
+   * @eventOf stormpath.ui-router.StormpathUIRouter
    *
    * @eventType broadcast on root scope
    *
@@ -374,9 +477,9 @@ StormpathUIRouter.prototype.emitUnauthenticated = function emitUnauthenticated(t
   /**
    * @ngdoc event
    *
-   * @name stormpath.$stormpath#$stateChangeUnauthenticated
+   * @name stormpath.ui-router.StormpathUIRouter#$stateChangeUnauthenticated
    *
-   * @eventOf stormpath.$stormpath
+   * @eventOf stormpath.ui-router.StormpathUIRouter
    *
    * @eventType broadcast on root scope
    *

--- a/src/stormpath.ui-router.js
+++ b/src/stormpath.ui-router.js
@@ -7,7 +7,7 @@
 *
 * @description
 *
-* This module provides the {@link stormpath.ui-router.StormpathUIRouter StormpathUIRouter}
+* This module provides the {@link stormpath.ui.router:StormpathUIRouter StormpathUIRouter}
 * service, which handles Stormpath's integration with UIRouter (both 0.*.* and 1.**).
 */
 angular
@@ -15,8 +15,8 @@ angular
   .service('StormpathUIRouter', StormpathUIRouter);
 
 /**
- * @private
- * @name stormpath.ui-router.StormpathUIRouterTransition
+ * @ngdoc service
+ * @name stormpath.ui.router:StormpathUIRouterTransition
  * @description
  *
  * Encapsulates UIRouter state transitions for both versions 0.*.* and 1.*.*
@@ -25,7 +25,7 @@ angular
  * standard state transition manually.
  *
  * Should <b>never</b> be instantiated in client code. This class is meant only
- * for private use in the {@link stormpath.ui-router.StormpathUIRouter StormpathUIRouter}
+ * for private use in the {@link stormpath.ui.router:StormpathUIRouter StormpathUIRouter}
  * service.
  */
 function StormpathUIRouterTransition($state, args) {
@@ -47,8 +47,8 @@ StormpathUIRouterTransition.prototype._parseArguments = function _parseArguments
 
 /**
  * @ngdoc method
- * @name stormpath.ui-router.StormpathUIRouterTransition#isLegacy
- * @methodOf stormpath.ui-router.StormpathUIRouterTransition
+ * @name isLegacy
+ * @methodOf stormpath.ui.router:StormpathUIRouterTransition
  *
  * @returns {Boolean} Whether this is UI Router < 1.0.0
  *
@@ -61,8 +61,8 @@ StormpathUIRouterTransition.prototype.isLegacy = function isLegacy() {
 
 /**
  * @ngdoc method
- * @name stormpath.ui-router.StormpathUIRouterTransition#sp
- * @methodOf stormpath.ui-router.StormpathUIRouterTransition
+ * @name sp
+ * @methodOf stormpath.ui.router:StormpathUIRouterTransition
  *
  * @returns {Object}
  * Stormpath configuration for this state, or empty object if none is defined
@@ -78,8 +78,8 @@ StormpathUIRouterTransition.prototype.sp = function sp() {
 
 /**
  * @ngdoc method
- * @name stormpath.ui-router.StormpathUIRouterTransition#authorities
- * @methodOf stormpath.ui-router.StormpathUIRouterTransition
+ * @name authorities
+ * @methodOf stormpath.ui.router:StormpathUIRouterTransition
  *
  * @returns {Array} List of roles authorized to enter this state
  *
@@ -100,8 +100,8 @@ StormpathUIRouterTransition.prototype.authorities = function authorities() {
 
 /**
  * @ngdoc method
- * @name stormpath.ui-router.StormpathUIRouterTransition#fromState
- * @methodOf stormpath.ui-router.StormpathUIRouterTransition
+ * @name fromState
+ * @methodOf stormpath.ui.router:StormpathUIRouterTransition
  *
  * @returns {State} State definition for state from which the transition is occurring
  *
@@ -116,8 +116,8 @@ StormpathUIRouterTransition.prototype.fromState = function fromState() {
 
 /**
  * @ngdoc method
- * @name stormpath.ui-router.StormpathUIRouterTransition#fromParams
- * @methodOf stormpath.ui-router.StormpathUIRouterTransition
+ * @name fromParams
+ * @methodOf stormpath.ui.router:StormpathUIRouterTransition
  *
  * @returns {Object} Parameters of the state currently being transitioned from
  *
@@ -132,8 +132,8 @@ StormpathUIRouterTransition.prototype.fromParams = function fromParams() {
 
 /**
  * @ngdoc method
- * @name stormpath.ui-router.StormpathUIRouterTransition#toState
- * @methodOf stormpath.ui-router.StormpathUIRouterTransition
+ * @name toState
+ * @methodOf stormpath.ui.router:StormpathUIRouterTransition
  *
  * @returns {State} State definition for state to which the transition is occurring
  *
@@ -148,8 +148,8 @@ StormpathUIRouterTransition.prototype.toState = function toState() {
 
 /**
  * @ngdoc method
- * @name stormpath.ui-router.StormpathUIRouterTransition#toParams
- * @methodOf stormpath.ui-router.StormpathUIRouterTransition
+ * @name toParams
+ * @methodOf stormpath.ui.router:StormpathUIRouterTransition
  *
  * @returns {Object} Parameters of the state currently being transitioned to
  *
@@ -164,8 +164,8 @@ StormpathUIRouterTransition.prototype.toParams = function toParams() {
 
 /**
  * @ngdoc method
- * @name stormpath.ui-router.StormpathUIRouterTransition#pause
- * @methodOf stormpath.ui-router.StormpathUIRouterTransition
+ * @name pause
+ * @methodOf stormpath.ui.router:StormpathUIRouterTransition
  *
  * @returns {Boolean} Always `false`
  *
@@ -187,8 +187,8 @@ StormpathUIRouterTransition.prototype.pause = function pause() {
 
 /**
  * @ngdoc method
- * @name stormpath.ui-router.StormpathUIRouterTransition#resume
- * @methodOf stormpath.ui-router.StormpathUIRouterTransition
+ * @name resume
+ * @methodOf stormpath.ui.router:StormpathUIRouterTransition
  *
  * @description
  * Continues the transition to the original target state, if prevented. Otherwise
@@ -200,8 +200,8 @@ StormpathUIRouterTransition.prototype.resume = function resume() {
 
 /**
  * @ngdoc method
- * @name stormpath.ui-router.StormpathUIRouterTransition#redirect
- * @methodOf stormpath.ui-router.StormpathUIRouterTransition
+ * @name redirect
+ * @methodOf stormpath.ui.router:StormpathUIRouterTransition
  *
  * @param {State|String} state State definition or state name
  * @param {Object} params State parameters
@@ -217,7 +217,7 @@ StormpathUIRouterTransition.prototype.redirect = function redirect(state, params
 
 /**
  * @ngdoc service
- * @name stormpath.ui-router.StormpathUIRouter
+ * @name stormpath.ui.router:StormpathUIRouter
  *
  * @requires $rootScope
  * @requires stormpath.userService.$user:$user
@@ -227,11 +227,11 @@ StormpathUIRouterTransition.prototype.redirect = function redirect(state, params
  * A wrapper around UI Router that allows Stormpath to connect to state transitions
  * and perform authentication, authorization and redirection.
  *
- * Emits {@link stormpath.ui-router.StormpathUIRouter#$stateChangeUnauthorized $stateChangeUnauthorized}
- * or {@link stormpath.ui-router.StormpathUIRouter#$stateChangeUnauthenticated $stateChangeUnauthenticated}
+ * Emits {@link stormpath.ui.router:StormpathUIRouter#-$stateChangeUnauthorized $stateChangeUnauthorized}
+ * or {@link stormpath.ui.router:StormpathUIRouter#-$stateChangeUnauthenticated $stateChangeUnauthenticated}
  * in case of authorization or authentication failure, to allow for further client handling.
  *
- * When initialized, {@link stormpath.ui-router.StormpathUIRouter#registerUIRouterInternals StormpathUIRouter.registerUIRouterInternals()}
+ * When initialized, {@link stormpath.ui.router:StormpathUIRouter#registerUIRouterInternals StormpathUIRouter.registerUIRouterInternals()}
  * <b>must</b> be called to inject `$state` and `$transitions` (if UIRouter >= 1.0.0) into the service.
  */
 function StormpathUIRouter($rootScope, $user, STORMPATH_CONFIG) {
@@ -242,8 +242,8 @@ function StormpathUIRouter($rootScope, $user, STORMPATH_CONFIG) {
 
 /**
  * @ngdoc metod
- * @name stormpath.ui-router.StormpathUIRouter#registerUIRouterInternals
- * @methodOf stormpath.ui-router.StormpathUIRouter
+ * @name registerUIRouterInternals
+ * @methodOf stormpath.ui.router:StormpathUIRouter
  *
  * @param {TransitionsService} $transitions UIRouter 1.*.* `$transitions` service. If undefined, UIRouter 0.*.* is assumed
  * @param {StateService} $state UIRouter `$state` service
@@ -264,8 +264,8 @@ StormpathUIRouter.prototype.registerUIRouterInternals = function registerInterna
 
 /**
  * @ngdoc method
- * @name stormpath.ui-router.StormpathUIRouter#isLegacy
- * @methodOf stormpath.ui-router.StormpathUIRouter
+ * @name isLegacy
+ * @methodOf stormpath.ui.router:StormpathUIRouter
  *
  * @returns {Boolean} Whether this is UI Router < 1.0.0
  *
@@ -278,8 +278,8 @@ StormpathUIRouter.prototype.isLegacy = function isLegacy() {
 
 /**
  * @ngdoc method
- * @name stormpath.ui-router.StormpathUIRouter#authorizeStateConfig
- * @methodOf stormpath.ui-router.StormpathUIRouter
+ * @name authorizeStateConfig
+ * @methodOf stormpath.ui.router:StormpathUIRouter
  *
  * @param {StormpathUIRouterTransition} transition Current transition
  * @returns {Boolean} Is the user authorized to make this state transition
@@ -310,8 +310,8 @@ StormpathUIRouter.prototype.authorizeStateConfig = function authorizeStateConfig
 
 /**
  * @ngdoc method
- * @name stormpath.ui-router.StormpathUIRouter#onStateChange
- * @methodOf stormpath.ui-router.StormpathUIRouter
+ * @name onStateChange
+ * @methodOf stormpath.ui.router:StormpathUIRouter
  *
  * @param {StormpathUIRouterTransition} transition Current state transition
  *
@@ -400,8 +400,8 @@ StormpathUIRouter.prototype.onStateChange = function onStateChange(transition) {
 
 /**
  * @ngdoc method
- * @name stormpath.ui-router.StormpathUIRouter#registerInterceptor
- * @methodOf stormpath.ui-router.StormpathUIRouter
+ * @name registerInterceptor
+ * @methodOf stormpath.ui.router:StormpathUIRouter
  *
  * @param {Object} config Stormpath UI router configuration
  *
@@ -409,7 +409,7 @@ StormpathUIRouter.prototype.onStateChange = function onStateChange(transition) {
  * Registers the UI Router interceptor to listen to state change events.
  * Abstracts the operation's differences between UI Router 0.*.* and 1.*.*.
  * The registered method is
- * {@link stormpath.ui-router.StormpathUIRouter#onStateChange StormpathUIRouter.onStateChange()}.
+ * {@link stormpath.ui.router:StormpathUIRouter#onStateChange StormpathUIRouter.onStateChange()}.
  */
 StormpathUIRouter.prototype.registerInterceptor = function registerInterceptor(config) {
   var self = this;
@@ -428,23 +428,22 @@ StormpathUIRouter.prototype.registerInterceptor = function registerInterceptor(c
 
 /**
  * @ngdoc method
- * @name stormpath.ui-router.StormpathUIRouter#emitUnauthorized
- * @methodOf stormpath.ui-router.StormpathUIRouter
+ * @name emitUnauthorized
+ * @methodOf stormpath.ui.router:StormpathUIRouter
  *
  * @param {StormpathUIRouterTransition} transition Current state transition
  *
  * @description
- * Emits the {@link stormpath.ui-router.StormpathUIRouter#$stateChangeUnauthorized $stateChangeUnauthorized}
+ * Emits the {@link stormpath.ui.router:StormpathUIRouter#$stateChangeUnauthorized $stateChangeUnauthorized}
  * event with the data about the target state to signify that the transition failed due to the user not
  * being authorized.
  */
 StormpathUIRouter.prototype.emitUnauthorized = function emitUnauthorized(transition) {
   /**
    * @ngdoc event
+   * @name stormpath.ui.router:StormpathUIRouter#$stateChangeUnauthorized
    *
-   * @name stormpath.ui-router.StormpathUIRouter#$stateChangeUnauthorized
-   *
-   * @eventOf stormpath.ui-router.StormpathUIRouter
+   * @eventOf stormpath.ui.router:StormpathUIRouter
    *
    * @eventType broadcast on root scope
    *
@@ -487,13 +486,13 @@ StormpathUIRouter.prototype.emitUnauthorized = function emitUnauthorized(transit
 
 /**
  * @ngdoc method
- * @name stormpath.ui-router.StormpathUIRouter#emitUnauthenticated
- * @methodOf stormpath.ui-router.StormpathUIRouter
+ * @name emitUnauthenticated
+ * @methodOf stormpath.ui.router:StormpathUIRouter
  *
  * @param {StormpathUIRouterTransition} transition Current state transition
  *
  * @description
- * Emits the {@link stormpath.ui-router.StormpathUIRouter#$stateChangeUnauthenticated $stateChangeUnauthenticated}
+ * Emits the {@link stormpath.ui.router:StormpathUIRouter#$stateChangeUnauthenticated $stateChangeUnauthenticated}
  * event with the data about the target state to signify that the transition failed due to the user not
  * being authenticated (i.e. having the permissions to access this route).
  */
@@ -501,9 +500,9 @@ StormpathUIRouter.prototype.emitUnauthenticated = function emitUnauthenticated(t
   /**
    * @ngdoc event
    *
-   * @name stormpath.ui-router.StormpathUIRouter#$stateChangeUnauthenticated
+   * @name stormpath.ui.router:StormpathUIRouter#$stateChangeUnauthenticated
    *
-   * @eventOf stormpath.ui-router.StormpathUIRouter
+   * @eventOf stormpath.ui.router:StormpathUIRouter
    *
    * @eventType broadcast on root scope
    *

--- a/src/stormpath.ui-router.js
+++ b/src/stormpath.ui-router.js
@@ -227,11 +227,11 @@ StormpathUIRouterTransition.prototype.redirect = function redirect(state, params
  * A wrapper around UI Router that allows Stormpath to connect to state transitions
  * and perform authentication, authorization and redirection.
  *
- * Emits {@link stormpath.ui.router:StormpathUIRouter#-$stateChangeUnauthorized $stateChangeUnauthorized}
- * or {@link stormpath.ui.router:StormpathUIRouter#-$stateChangeUnauthenticated $stateChangeUnauthenticated}
+ * Emits {@link stormpath.ui.router:StormpathUIRouter#events_$stateChangeUnauthorized $stateChangeUnauthorized}
+ * or {@link stormpath.ui.router:StormpathUIRouter#events_$stateChangeUnauthenticated $stateChangeUnauthenticated}
  * in case of authorization or authentication failure, to allow for further client handling.
  *
- * When initialized, {@link stormpath.ui.router:StormpathUIRouter#registerUIRouterInternals StormpathUIRouter.registerUIRouterInternals()}
+ * When initialized, {@link stormpath.ui.router:StormpathUIRouter#methods_registerUIRouterInternals StormpathUIRouter.registerUIRouterInternals()}
  * <b>must</b> be called to inject `$state` and `$transitions` (if UIRouter >= 1.0.0) into the service.
  */
 function StormpathUIRouter($rootScope, $user, STORMPATH_CONFIG) {

--- a/src/stormpath.ui-router.js
+++ b/src/stormpath.ui-router.js
@@ -1,0 +1,280 @@
+function StormpathUIRouterTransition($state, args) {
+  this.$state = $state;
+  this._parseArguments(args);
+}
+
+StormpathUIRouterTransition.prototype._parseArguments = function _parseArguments(args) {
+  if (args.length >= 5) {
+    this.$event = args[0];
+    this.$toState = args[1];
+    this.$toParams = args[2];
+    this.$fromState = args[3];
+    this.$fromParams = args[4];
+  } else {
+    this.$trans = args[0];
+  }
+};
+
+StormpathUIRouterTransition.prototype.isLegacy = function isLegacy() {
+  return typeof this.$trans === 'undefined';
+};
+
+StormpathUIRouterTransition.prototype.sp = function sp() {
+  return this.toState().sp || {};
+};
+
+StormpathUIRouterTransition.prototype.authorities = function authorities() {
+  var toState = this.toState();
+
+  if (toState.data && toState.data.authorities) {
+    return toState.data.authorities;
+  }
+};
+
+StormpathUIRouterTransition.prototype.fromState = function fromState() {
+  return this.$fromState || this.$trans.from();
+};
+
+StormpathUIRouterTransition.prototype.fromParams = function fromParams() {
+  return this.$fromParams || this.$trans.params('from');
+};
+
+StormpathUIRouterTransition.prototype.toState = function toState() {
+  return this.$toState || this.$trans.to();
+};
+
+StormpathUIRouterTransition.prototype.toParams = function toParams() {
+  return this.$toParams || this.$trans.params();
+};
+
+StormpathUIRouterTransition.prototype.pause = function pause() {
+  if (this.isLegacy()) {
+    this.$event.preventDefault();
+  }
+
+  return false;
+};
+
+StormpathUIRouterTransition.prototype.resume = function resume() {
+  this.redirect(this.toState(), this.toParams());
+};
+
+StormpathUIRouterTransition.prototype.undo = function undo() {
+  if (this.isLegacy()) {
+    return this.$event.preventDefault();
+  }
+
+  var origin = this.makeTargetState(this.fromState(), this.fromParams());
+  return this.$trans.redirect(origin);
+};
+
+StormpathUIRouterTransition.prototype.redirect = function redirect(state, params) {
+  return this.$state.go(state.name || state, params);
+};
+
+function StormpathUIRouter($rootScope, $user, STORMPATH_CONFIG) {
+  this.$rootScope = $rootScope;
+  this.$user = $user;
+  this.STORMPATH_CONFIG = STORMPATH_CONFIG;
+}
+
+StormpathUIRouter.prototype.registerUIRouterInternals = function registerInternals($transitions, $state) {
+  this.$transitions = $transitions;
+  this.$state = $state;
+  return this;
+};
+
+
+StormpathUIRouter.prototype.isLegacy = function isLegacy() {
+  return typeof this.$transitions === 'undefined';
+};
+
+StormpathUIRouter.prototype.authorizeStateConfig = function authorizeStateConfig(transition) {
+  var sp = transition.sp();
+  var authorities = sp.authorities();
+
+  if (sp && sp.authorize && sp.authorize.group) {
+    return this.$user.currentUser.inGroup(sp.authorize.group);
+  } else if (authorities) {
+    // add support for reading from JHipster's data: { authorities: ['ROLE_ADMIN'] }
+    // https://github.com/stormpath/stormpath-sdk-angularjs/issues/190
+    var roles = authorities.filter(function(authority) {
+      return this.$user.currentUser.inGroup(authority);
+    });
+    return roles.length > 0;
+  }
+
+  console.error('Unknown authorize configuration for spStateConfig', spStateConfig);
+  return false;
+};
+
+StormpathUIRouter.prototype.onStateChange = function onStateChange(transition) {
+  var self = this;
+  var sp = transition.sp();
+  var authorities = transition.authorities();
+  var needsAuth = sp.authenticate
+    || sp.authorize
+    || (authorities && authorities.length);
+
+  if (needsAuth && !this.$user.currentUser) {
+    transition.pause();
+
+    return this.$user.get().then(function() {
+      // The user is authenticated, continue to the requested state
+      if (sp.authorize || (authorities && authorities.length)) {
+        if (this.authorizeStateConfig(transition)) {
+          return transition.resume();
+        }
+
+        self.emitUnauthorized(transition);
+        return false;
+      }
+
+      return transition.resume();
+    }).catch(function() {
+      self.emitUnauthenticated(transition);
+      return false;
+    });
+  }else if (sp.waitForUser && (this.$user.currentUser===null)) {
+    transition.pause();
+
+    return this.$user.get().finally(function() {
+      return transition.resume();
+    });
+  } else if (this.$user.currentUser && (sp.authorize || (authorities && authorities.length))) {
+    if (!this.authorizeStateConfig(transition)) {
+      this.emitUnauthorized(transition);
+      return transition.pause();
+    }
+  }else if (transition.toState().name === this.config.loginState) {
+    /*
+      If the user is already logged in, we will redirect
+      away from the login page and send the user to the
+      post login state.
+      */
+    if (this.$user.currentUser !== false) {
+      transition.pause();
+
+      return this.$user.get().finally(function() {
+        if (self.$user.currentUser && self.$user.currentUser.href) {
+          return transition.redirect(self.config.defaultPostLoginState, {});
+        }
+
+        return transition.resume();
+      });
+    }
+  }
+};
+
+StormpathUIRouter.prototype.registerInterceptor = function registerInterceptor(config) {
+  var self = this;
+  this.config = config;
+
+  if (this.isLegacy()) {
+    return this.$rootScope.$on('$stateChangeStart', function() {
+      self.onStateChange(new StormpathUIRouterTransition(self.$state, arguments));
+    });
+  }
+
+  this.$transitions.onStart({}, function() {
+    self.onStateChange(new StormpathUIRouterTransition(self.$state, arguments));
+  });
+};
+
+StormpathUIRouter.prototype.emitUnauthorized = function emitUnauthorized(transition) {
+  /**
+   * @ngdoc event
+   *
+   * @name stormpath.$stormpath#$stateChangeUnauthorized
+   *
+   * @eventOf stormpath.$stormpath
+   *
+   * @eventType broadcast on root scope
+   *
+   * @param {Object} event
+   *
+   * Angular event object.
+   *
+   * @param {Object} toState The state that the user attempted to access.
+   *
+   * @param {Object} toParams The state params of the state that the user
+   * attempted to access.
+   *
+   * @description
+   *
+   * This event is broadcast when a UI state change is prevented,
+   * because the user is not authorized by the rules defined in the
+   * {@link stormpath.SpStateConfig:SpStateConfig Stormpath State Configuration}
+   * for the requested state.
+   *
+   * Use this event if you want to implement your own strategy for telling
+   * the user that they are forbidden from viewing that state.
+   *
+   * To receive this event, you must be using the UI Router integration.
+   *
+   * @example
+   *
+   * <pre>
+   *   $rootScope.$on('$stateChangeUnauthorized',function(e,toState,toParams){
+   *     // Your custom logic for deciding how the user should be
+   *     // notified that they are forbidden from this state
+   *   });
+   * </pre>
+   */
+  this.$rootScope.$broadcast(
+    this.STORMPATH_CONFIG.STATE_CHANGE_UNAUTHORIZED,
+    transition.toState(),
+    transition.toParams()
+  );
+};
+
+StormpathUIRouter.prototype.emitUnauthenticated = function emitUnauthenticated(transition) {
+  /**
+   * @ngdoc event
+   *
+   * @name stormpath.$stormpath#$stateChangeUnauthenticated
+   *
+   * @eventOf stormpath.$stormpath
+   *
+   * @eventType broadcast on root scope
+   *
+   * @param {Object} event
+   *
+   * Angular event object.
+   *
+   * @param {Object} toState The state that the user attempted to access.
+   *
+   * @param {Object} toParams The state params of the state that the user
+   * attempted to access.
+   *
+   * @description
+   *
+   * This event is broadcast when a UI state change is prevented,
+   * because the user is not logged in.
+   *
+   * Use this event if you want to implement your own strategy for
+   * presenting the user with a login form.
+   *
+   * To receive this event, you must be using the UI Router integration.
+   *
+   * @example
+   *
+   * <pre>
+   *   $rootScope.$on('$stateChangeUnauthenticated',function(e,toState,toParams){
+   *     // Your custom logic for deciding how the user should login, and
+   *     // if you want to redirect them to the desired state afterwards
+   *   });
+   * </pre>
+   */
+  this.$rootScope.$broadcast(
+    this.STORMPATH_CONFIG.STATE_CHANGE_UNAUTHENTICATED,
+    transition.toState(),
+    transition.toParams()
+  );
+};
+
+StormpathUIRouter.$inject = ['$rootScope', '$user', 'STORMPATH_CONFIG'];
+
+angular
+  .module('stormpath.ui-router', ['stormpath.userService'])
+  .service('StormpathUIRouter', StormpathUIRouter);

--- a/src/stormpath.ui-router.js
+++ b/src/stormpath.ui-router.js
@@ -426,6 +426,18 @@ StormpathUIRouter.prototype.registerInterceptor = function registerInterceptor(c
   });
 };
 
+/**
+ * @ngdoc method
+ * @name stormpath.ui-router.StormpathUIRouter#emitUnauthorized
+ * @methodOf stormpath.ui-router.StormpathUIRouter
+ *
+ * @param {StormpathUIRouterTransition} transition Current state transition
+ *
+ * @description
+ * Emits the {@link stormpath.ui-router.StormpathUIRouter#$stateChangeUnauthorized $stateChangeUnauthorized}
+ * event with the data about the target state to signify that the transition failed due to the user not
+ * being authorized.
+ */
 StormpathUIRouter.prototype.emitUnauthorized = function emitUnauthorized(transition) {
   /**
    * @ngdoc event
@@ -473,6 +485,18 @@ StormpathUIRouter.prototype.emitUnauthorized = function emitUnauthorized(transit
   );
 };
 
+/**
+ * @ngdoc method
+ * @name stormpath.ui-router.StormpathUIRouter#emitUnauthenticated
+ * @methodOf stormpath.ui-router.StormpathUIRouter
+ *
+ * @param {StormpathUIRouterTransition} transition Current state transition
+ *
+ * @description
+ * Emits the {@link stormpath.ui-router.StormpathUIRouter#$stateChangeUnauthenticated $stateChangeUnauthenticated}
+ * event with the data about the target state to signify that the transition failed due to the user not
+ * being authenticated (i.e. having the permissions to access this route).
+ */
 StormpathUIRouter.prototype.emitUnauthenticated = function emitUnauthenticated(transition) {
   /**
    * @ngdoc event


### PR DESCRIPTION
Provides a wrapper around the UI Router handling to allow for both UI Router 0.*.* and 1.*.* to be used. Refactors and abstracts the UI Router handling, also moving it into another module.

Was tested with UI Router `v1.0.0-rc.1` for v1 support and `v0.3.1` for backwards compatibility.

Fixes #176 