### PR TITLE
Issue/214 - Fix IE11 error for $isCurrentDomain

### DIFF
--- a/src/stormpath.utils.js
+++ b/src/stormpath.utils.js
@@ -13,7 +13,7 @@ angular.module('stormpath.utils', ['stormpath.CONFIG'])
     var link = $window.document.createElement('a');
     link.href = url;
 
-    return $window.location.host === link.host.replace(/:443/, "");
+    return (link.host === "") || $window.location.host === link.host.replace(/:443$/, "");
   };
 }])
 .constant('$spHeaders', {

--- a/src/stormpath.utils.js
+++ b/src/stormpath.utils.js
@@ -13,7 +13,7 @@ angular.module('stormpath.utils', ['stormpath.CONFIG'])
     var link = $window.document.createElement('a');
     link.href = url;
 
-    return $window.location.host === link.host;
+    return $window.location.host === link.hostname;
   };
 }])
 .constant('$spHeaders', {

--- a/src/stormpath.utils.js
+++ b/src/stormpath.utils.js
@@ -13,7 +13,7 @@ angular.module('stormpath.utils', ['stormpath.CONFIG'])
     var link = $window.document.createElement('a');
     link.href = url;
 
-    return $window.location.host === link.hostname;
+    return $window.location.host === link.host.replace(/:443/, "");
   };
 }])
 .constant('$spHeaders', {


### PR DESCRIPTION
Switch $isCurrentDomain to compare $window.location.host to link.hostname.  

On IE11, the old link.host returns domain_name:443, while other browsers return domain_name.
link.hostname returns only the domain_name in all browsers.  

Tested in Edge, IE11, Chrome